### PR TITLE
Replace placeholder script with CPU, RAM, and network monitors

### DIFF
--- a/cyberplasma/scripts/cpu.sh
+++ b/cyberplasma/scripts/cpu.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Output CPU usage percentage as JSON.
+# Avoids elevated privileges and ensures sanitized output.
+set -euo pipefail
+
+read -r _ user nice system idle iowait irq softirq steal guest < /proc/stat
+prev_total=$((user + nice + system + idle + iowait + irq + softirq + steal))
+prev_idle=$((idle + iowait))
+
+sleep 0.2
+
+read -r _ user nice system idle iowait irq softirq steal guest < /proc/stat
+total=$((user + nice + system + idle + iowait + irq + softirq + steal))
+idle_all=$((idle + iowait))
+
+delta_total=$((total - prev_total))
+delta_idle=$((idle_all - prev_idle))
+
+usage=$(awk -v total="$delta_total" -v idle="$delta_idle" '
+BEGIN {
+  if (total > 0) {
+    printf "%.2f", (1 - idle / total) * 100
+  } else {
+    print "0.00"
+  }
+}')
+
+printf '{"usage":%s}\n' "$usage"

--- a/cyberplasma/scripts/net.sh
+++ b/cyberplasma/scripts/net.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Output network bytes for an interface as JSON.
+# Usage: net.sh <interface>
+# Ensures input sanitization and avoids elevated privileges.
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  printf 'Usage: %s <interface>\n' "$(basename "$0")" >&2
+  exit 1
+fi
+iface="$1"
+# Allow only alphanumeric, hyphen, and underscore in interface name.
+if [[ ! "$iface" =~ ^[A-Za-z0-9_-]+$ ]]; then
+  printf 'Invalid interface name\n' >&2
+  exit 1
+fi
+
+rx_path="/sys/class/net/$iface/statistics/rx_bytes"
+tx_path="/sys/class/net/$iface/statistics/tx_bytes"
+if [[ ! -r "$rx_path" || ! -r "$tx_path" ]]; then
+  printf 'Interface not found\n' >&2
+  exit 1
+fi
+rx=$(cat "$rx_path")
+tx=$(cat "$tx_path")
+
+printf '{"interface":"%s","rx_bytes":%s,"tx_bytes":%s}\n' "$iface" "$rx" "$tx"

--- a/cyberplasma/scripts/placeholder.sh
+++ b/cyberplasma/scripts/placeholder.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-# Placeholder script for CyberPlasma.
-# Include functions with proper input validation.
-# Avoid running with elevated privileges or exposing secrets.

--- a/cyberplasma/scripts/ram.sh
+++ b/cyberplasma/scripts/ram.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Output RAM usage as JSON.
+# Avoids elevated privileges and ensures sanitized output.
+set -euo pipefail
+
+meminfo=/proc/meminfo
+total=$(awk '/^MemTotal:/ {print $2}' "$meminfo")
+available=$(awk '/^MemAvailable:/ {print $2}' "$meminfo")
+used=$((total - available))
+
+percent=$(awk -v u="$used" -v t="$total" 'BEGIN { if (t > 0) printf "%.2f", (u / t) * 100; else print "0.00" }')
+
+printf '{"total_kb":%s,"used_kb":%s,"percent":%s}\n' "$total" "$used" "$percent"


### PR DESCRIPTION
## Summary
- remove placeholder script in favor of dedicated cpu, ram, and net monitoring scripts
- output sanitized JSON without requiring elevated privileges

## Testing
- `./cyberplasma/scripts/cpu.sh`
- `./cyberplasma/scripts/ram.sh`
- `./cyberplasma/scripts/net.sh lo`


------
https://chatgpt.com/codex/tasks/task_e_68a3e819fbec8325a18615fd29f522f9