### PR TITLE
Add systemd user units for CyberPlasma services

### DIFF
--- a/cyberplasma/systemd/user/README.md
+++ b/cyberplasma/systemd/user/README.md
@@ -1,0 +1,25 @@
+# CyberPlasma systemd user units
+
+These units manage optional components for the CyberPlasma setup.
+
+## Units
+- `cyberplasma.target` – groups all CyberPlasma services.
+- `eww.service` – launches EWW widgets.
+- `glava.service` – starts the GLava audio visualizer.
+- `yakuake.service` – runs the Yakuake drop-down terminal.
+
+## Dependencies
+- `eww` for `eww.service`
+- `glava` for `glava.service`
+- `yakuake` for `yakuake.service`
+
+Ensure these packages are installed before enabling the services.
+
+## Enablement
+Copy the unit files to `~/.config/systemd/user/` and enable the target:
+
+```bash
+systemctl --user enable --now cyberplasma.target
+```
+
+This will pull in the individual services via `WantedBy=cyberplasma.target`.

--- a/cyberplasma/systemd/user/cyberplasma.target
+++ b/cyberplasma/systemd/user/cyberplasma.target
@@ -1,0 +1,8 @@
+# CyberPlasma target for grouping related user services.
+# Limit permissions and avoid exposing sensitive paths or data.
+
+[Unit]
+Description=CyberPlasma target
+
+[Install]
+WantedBy=default.target

--- a/cyberplasma/systemd/user/eww.service
+++ b/cyberplasma/systemd/user/eww.service
@@ -1,0 +1,15 @@
+# CyberPlasma EWW widgets service.
+# Requires the `eww` executable to be installed.
+# Limit permissions and avoid exposing sensitive paths or data.
+
+[Unit]
+Description=CyberPlasma EWW widgets
+After=graphical-session.target
+
+[Service]
+ExecStart=eww daemon
+ExecStartPost=eww open cyberbar
+Restart=on-failure
+
+[Install]
+WantedBy=cyberplasma.target

--- a/cyberplasma/systemd/user/glava.service
+++ b/cyberplasma/systemd/user/glava.service
@@ -1,0 +1,14 @@
+# CyberPlasma GLava visualizer service.
+# Requires the `glava` executable to be installed.
+# Limit permissions and avoid exposing sensitive paths or data.
+
+[Unit]
+Description=CyberPlasma GLava visualizer
+After=graphical-session.target
+
+[Service]
+ExecStart=glava
+Restart=on-failure
+
+[Install]
+WantedBy=cyberplasma.target

--- a/cyberplasma/systemd/user/yakuake.service
+++ b/cyberplasma/systemd/user/yakuake.service
@@ -1,0 +1,14 @@
+# CyberPlasma Yakuake drop-down terminal service.
+# Requires the `yakuake` executable to be installed.
+# Limit permissions and avoid exposing sensitive paths or data.
+
+[Unit]
+Description=CyberPlasma Yakuake
+After=graphical-session.target
+
+[Service]
+ExecStart=yakuake
+Restart=on-failure
+
+[Install]
+WantedBy=cyberplasma.target


### PR DESCRIPTION
## Summary
- Add `cyberplasma.target` to group CyberPlasma user services
- Provide `eww`, `glava`, and `yakuake` user services
- Document dependencies and enablement steps for the new units

## Testing
- `systemd-analyze --user verify cyberplasma/systemd/user/cyberplasma.target cyberplasma/systemd/user/eww.service cyberplasma/systemd/user/glava.service cyberplasma/systemd/user/yakuake.service` *(fails: No such device or address)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e81e1e98832589930b2bee250131