### PR TITLE
Add Bismuth toggle script and exclusions

### DIFF
--- a/bismuth/config.json
+++ b/bismuth/config.json
@@ -1,0 +1,8 @@
+{
+  "//": "Bismuth configuration with per-application exclusions.",
+  "float_filter": [
+    { "class": "org.kde.plasmashell" },
+    { "class": "krunner" },
+    { "class": "yakuake" }
+  ]
+}

--- a/kde/khotkeysrc
+++ b/kde/khotkeysrc
@@ -1,0 +1,34 @@
+# KDE global shortcuts for toggling Bismuth via toggle_tiling.sh
+# Generated for CyberPlasma.
+
+[Main]
+Version=3
+DataCount=1
+
+[Data_1]
+Comment=Toggle Bismuth tiling
+Enabled=true
+Name=Toggle Bismuth
+Type=GENERIC
+
+[Data_1/Actions]
+ActionsCount=1
+
+[Data_1/Actions/0]
+Type=COMMAND_URL
+CommandURL=~/scripts/toggle_tiling.sh
+
+[Data_1/Triggers]
+TriggersCount=3
+
+[Data_1/Triggers/0]
+Type=SHORTCUT
+Shortcut=Meta+T
+
+[Data_1/Triggers/1]
+Type=SHORTCUT
+Shortcut=Meta+Shift+T
+
+[Data_1/Triggers/2]
+Type=SHORTCUT
+Shortcut=Meta+Alt+T

--- a/scripts/toggle_tiling.sh
+++ b/scripts/toggle_tiling.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Toggle Bismuth tiling in KDE and record current mode.
+# Writes either "tiling" or "floating" to a state file.
+
+set -euo pipefail
+
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}"
+STATE_FILE="$STATE_DIR/bismuth_mode"
+
+mkdir -p "$STATE_DIR"
+
+if qdbus org.kde.KWin /Scripting org.kde.KWin.Scripting.isScriptLoaded bismuth &>/dev/null; then
+    qdbus org.kde.KWin /Scripting org.kde.KWin.Scripting.unloadScript bismuth >/dev/null
+    MODE="floating"
+else
+    qdbus org.kde.KWin /Scripting org.kde.KWin.Scripting.loadScript bismuth >/dev/null
+    MODE="tiling"
+fi
+
+echo "$MODE" > "$STATE_FILE"


### PR DESCRIPTION
## Summary
- add script to toggle Bismuth tiling and write state
- define KDE shortcut mappings for the toggle script
- include Bismuth config documenting floating/excluded apps

## Testing
- `bash -n scripts/toggle_tiling.sh`
- `jq . bismuth/config.json`

------
https://chatgpt.com/codex/tasks/task_e_68a3e82b16f08325bff95a67223ba9cc