### PR TITLE
feat: centralize CyberPlasma colors for widgets

### DIFF
--- a/cyberplasma/style.scss
+++ b/cyberplasma/style.scss
@@ -1,3 +1,39 @@
-/* Placeholder SCSS for CyberPlasma theme. */
-/* Define mixins and styles securely. */
-/* Do not import untrusted code or expose sensitive data. */
+/* CyberPlasma styles using colors from theme.env */
+* {
+  all: unset;
+  box-sizing: border-box;
+}
+
+$bg: env(BG);
+$fg: env(FG);
+$panel: env(PANEL);
+$accent: env(ACCENT);
+$border: env(BORDER);
+
+.top-bar {
+  background-color: $panel;
+  color: $fg;
+  border-bottom: 1px solid $border;
+}
+
+.left-column {
+  background-color: $bg;
+  color: $fg;
+  border-right: 1px solid $border;
+}
+
+.mpris-controls {
+  background-color: $panel;
+  color: $fg;
+  padding: 0.5rem;
+
+  button {
+    background: transparent;
+    color: $accent;
+    padding: 0.25rem;
+
+    &:hover {
+      background-color: $border;
+    }
+  }
+}

--- a/cyberplasma/theme.env
+++ b/cyberplasma/theme.env
@@ -1,3 +1,8 @@
-# Placeholder environment variables for CyberPlasma theme.
-# Define key-value pairs for colors and fonts.
-# Avoid storing secrets or sensitive credentials.
+# CyberPlasma unified color variables
+# Colors shared between Plasma, terminal, and EWW widgets.
+BG=#0d0d17
+FG=#e0e0e0
+PANEL=#161626
+ACCENT=#bc13fe
+ACCENT_ALT=#0ff3ff
+BORDER=#2a2a3b


### PR DESCRIPTION
## Summary
- add unified color variables in `theme.env`
- style EWW widgets with theme colors in `style.scss`

## Testing
- `npx sass cyberplasma/style.scss /tmp/style.css` *(fails: 403 Forbidden)*
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3eebf4e888325a49cd6355751b22e