### PR TITLE
Report network throughput in kB per second

### DIFF
--- a/cyberplasma/scripts/net.sh
+++ b/cyberplasma/scripts/net.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Output network bytes for an interface as JSON.
+# Output network transfer rate in kB/s for an interface as JSON.
 # Usage: net.sh <interface>
 # Ensures input sanitization and avoids elevated privileges.
 set -euo pipefail
@@ -21,7 +21,14 @@ if [[ ! -r "$rx_path" || ! -r "$tx_path" ]]; then
   printf 'Interface not found\n' >&2
   exit 1
 fi
-rx=$(cat "$rx_path")
-tx=$(cat "$tx_path")
 
-printf '{"interface":"%s","rx_bytes":%s,"tx_bytes":%s}\n' "$iface" "$rx" "$tx"
+rx1=$(<"$rx_path")
+tx1=$(<"$tx_path")
+sleep 1
+rx2=$(<"$rx_path")
+tx2=$(<"$tx_path")
+
+rx_rate=$(awk -v r1="$rx1" -v r2="$rx2" 'BEGIN {printf "%.2f", (r2 - r1)/1024}')
+tx_rate=$(awk -v t1="$tx1" -v t2="$tx2" 'BEGIN {printf "%.2f", (t2 - t1)/1024}')
+
+printf '{"interface":"%s","rx_kBps":%s,"tx_kBps":%s}\n' "$iface" "$rx_rate" "$tx_rate"


### PR DESCRIPTION
## Summary
- Sample interface counters over ~1s and compute RX/TX rates in kB/s
- Preserve interface name sanitization while reporting rate

## Testing
- `bash -n cyberplasma/scripts/net.sh`
- `./cyberplasma/scripts/net.sh lo`
- `./cyberplasma/scripts/net.sh 'eth0;'` (fails with "Invalid interface name")

------
https://chatgpt.com/codex/tasks/task_e_68a3eeb3dd1c832581af26cc62580bca