### PR TITLE
Float media, Steam, and Wine apps in Bismuth

### DIFF
--- a/bismuth/config.json
+++ b/bismuth/config.json
@@ -3,6 +3,12 @@
   "float_filter": [
     { "class": "org.kde.plasmashell" },
     { "class": "krunner" },
-    { "class": "yakuake" }
+    { "class": "yakuake" },
+    { "class": "mpv" },
+    { "class": "vlc" },
+    { "class": "steam" },
+    { "class": "kdenlive" },
+    { "class": "^steam_app.*" },
+    { "class": "^[Ww]ine$" }
   ]
 }


### PR DESCRIPTION
## Summary
- float mpv, VLC, Steam, Kdenlive
- match Steam Proton/Wine classes so games float

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3eeaafa888325817f0a34db30f944