### PR TITLE
docs: update tiling shortcuts and eww commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ An EWW configuration will be provided in a future update. Once available:
 2. Start the daemon and open the widgets:
    ```bash
    eww daemon
-   eww open cyberbar
+   eww open top_bar
+   eww open left_column
    ```
 
 ## GridMode and FreeMode
@@ -43,6 +44,7 @@ Use the following shortcuts to switch between modes:
 
 - `Meta+G` toggles **GridMode**.
 - `Meta+F` toggles **FreeMode**.
+- `Meta+T`, `Meta+Shift+T`, and `Meta+Alt+T` toggle Bismuth tiling on or off.
 
 ### Persistence
 The current mode is remembered and restored on login so your preferred layout


### PR DESCRIPTION
## Summary
- document Meta+T, Meta+Shift+T, and Meta+Alt+T shortcuts for toggling tiling
- replace `eww open cyberbar` with `eww open top_bar` and `eww open left_column`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3eea691c48325a89c121f90a5613c