### PR TITLE
feat: add metric widgets and media controls

### DIFF
--- a/cyberplasma/eww/config.yuck
+++ b/cyberplasma/eww/config.yuck
@@ -1,11 +1,22 @@
-# Placeholder Eww configuration file for CyberPlasma.
-# Define widgets and layouts here.
-# Ensure commands are sanitized and avoid executing untrusted code.
+;; CyberPlasma Eww configuration
 
-# Include widget definitions
+;; Include widget definitions
 (include "./widgets/top_bar.yuck")
 (include "./widgets/left_column.yuck")
 (include "./widgets/mpris_controls.yuck")
 
-# Reference shared styles
-(include "../style.scss")
+;; Link shared styles
+(include-css "../style.scss")
+
+;; Expose widgets as windows
+(defwindow top_bar
+  :focusable false
+  (top_bar))
+
+(defwindow left_column
+  :focusable false
+  (left_column))
+
+(defwindow mpris_controls
+  :focusable false
+  (mpris_controls))

--- a/cyberplasma/eww/widgets/left_column.yuck
+++ b/cyberplasma/eww/widgets/left_column.yuck
@@ -1,3 +1,8 @@
-# Left column widget placeholder
+;; Left column widget with network metrics and media controls
+(defpoll net :interval "2s" :command "../scripts/net.sh eth0" :json true)
+
 (defwidget left_column []
-  (box :class "left-column"))
+  (box :class "left-column" :orientation "v" :spacing 8
+       (label :class "net-rx" :text "Rx ${net.rx_bytes}")
+       (label :class "net-tx" :text "Tx ${net.tx_bytes}")
+       (mpris_controls)))

--- a/cyberplasma/eww/widgets/mpris_controls.yuck
+++ b/cyberplasma/eww/widgets/mpris_controls.yuck
@@ -1,3 +1,6 @@
-# MPRIS controls widget placeholder
+;; Media player controls using playerctl
 (defwidget mpris_controls []
-  (box :class "mpris-controls"))
+  (box :class "mpris-controls" :space-evenly true
+       (button :class "mpris-prev" :onclick "playerctl previous" "⏮")
+       (button :class "mpris-play" :onclick "playerctl play-pause" "⏯")
+       (button :class "mpris-next" :onclick "playerctl next" "⏭")))

--- a/cyberplasma/eww/widgets/top_bar.yuck
+++ b/cyberplasma/eww/widgets/top_bar.yuck
@@ -1,3 +1,8 @@
-# Top bar widget placeholder
+;; Top bar widget with CPU and RAM metrics
+(defpoll cpu :interval "1s" :command "../scripts/cpu.sh" :json true)
+(defpoll ram :interval "5s" :command "../scripts/ram.sh" :json true)
+
 (defwidget top_bar []
-  (box :class "top-bar"))
+  (box :class "top-bar" :space-evenly true
+       (label :class "cpu" :text "${cpu.usage}%")
+       (label :class "ram" :text "${ram.percent}%")))


### PR DESCRIPTION
## Summary
- Build top bar widget showing CPU and RAM usage
- Add left column widget with network metrics and embedded player controls
- Wire up mpris controls and expose widgets in Eww config with stylesheet include

## Testing
- `eww --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ee90c91c8325933a34de4f94eeb0