### PR TITLE
Ensure EWW widgets top_bar and left_column start

### DIFF
--- a/cyberplasma/systemd/user/README.md
+++ b/cyberplasma/systemd/user/README.md
@@ -4,7 +4,7 @@ These units manage optional components for the CyberPlasma setup.
 
 ## Units
 - `cyberplasma.target` – groups all CyberPlasma services.
-- `eww.service` – launches EWW widgets.
+- `eww.service` – launches EWW widgets (`top_bar`, `left_column`).
 - `glava.service` – starts the GLava audio visualizer.
 - `yakuake.service` – runs the Yakuake drop-down terminal.
 
@@ -14,6 +14,9 @@ These units manage optional components for the CyberPlasma setup.
 - `yakuake` for `yakuake.service`
 
 Ensure these packages are installed before enabling the services.
+
+## Widgets
+The `eww.service` expects widgets named `top_bar` and `left_column` to be defined in your EWW configuration.
 
 ## Enablement
 Copy the unit files to `~/.config/systemd/user/` and enable the target:

--- a/cyberplasma/systemd/user/eww.service
+++ b/cyberplasma/systemd/user/eww.service
@@ -8,7 +8,8 @@ After=graphical-session.target
 
 [Service]
 ExecStart=eww daemon
-ExecStartPost=eww open cyberbar
+ExecStartPost=eww open top_bar
+ExecStartPost=eww open left_column
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
## Summary
- open `top_bar` and `left_column` widgets after the EWW daemon starts
- document the required widget names for `eww.service`

## Testing
- `pytest >/tmp/pytest.log 2>&1 && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68a3ee9927d48325897a1e1236d8fd6d