### PR TITLE
Persist and restore Bismuth tiling mode

### DIFF
--- a/cyberplasma/systemd/user/README.md
+++ b/cyberplasma/systemd/user/README.md
@@ -7,11 +7,13 @@ These units manage optional components for the CyberPlasma setup.
 - `eww.service` – launches EWW widgets.
 - `glava.service` – starts the GLava audio visualizer.
 - `yakuake.service` – runs the Yakuake drop-down terminal.
+- `bismuth-mode.service` – restores the last Bismuth tiling mode on login.
 
 ## Dependencies
 - `eww` for `eww.service`
 - `glava` for `glava.service`
 - `yakuake` for `yakuake.service`
+- `bismuth` for `bismuth-mode.service`
 
 Ensure these packages are installed before enabling the services.
 

--- a/cyberplasma/systemd/user/bismuth-mode.service
+++ b/cyberplasma/systemd/user/bismuth-mode.service
@@ -1,0 +1,12 @@
+# Restore Bismuth tiling mode at login.
+# Runs the apply_bismuth_mode script if a saved mode exists.
+
+[Unit]
+Description=Restore Bismuth tiling mode
+After=graphical-session.target
+
+[Service]
+ExecStart=%h/scripts/apply_bismuth_mode.sh
+
+[Install]
+WantedBy=cyberplasma.target

--- a/kde/khotkeysrc
+++ b/kde/khotkeysrc
@@ -1,9 +1,9 @@
-# KDE global shortcuts for toggling Bismuth via toggle_tiling.sh
+# KDE global shortcuts for Bismuth mode control via toggle_tiling.sh
 # Generated for CyberPlasma.
 
 [Main]
 Version=3
-DataCount=1
+DataCount=3
 
 [Data_1]
 Comment=Toggle Bismuth tiling
@@ -19,16 +19,48 @@ Type=COMMAND_URL
 CommandURL=~/scripts/toggle_tiling.sh
 
 [Data_1/Triggers]
-TriggersCount=3
+TriggersCount=1
 
 [Data_1/Triggers/0]
 Type=SHORTCUT
 Shortcut=Meta+T
 
-[Data_1/Triggers/1]
+[Data_2]
+Comment=Enable Bismuth grid mode
+Enabled=true
+Name=Bismuth Grid
+Type=GENERIC
+
+[Data_2/Actions]
+ActionsCount=1
+
+[Data_2/Actions/0]
+Type=COMMAND_URL
+CommandURL=~/scripts/toggle_tiling.sh --grid
+
+[Data_2/Triggers]
+TriggersCount=1
+
+[Data_2/Triggers/0]
 Type=SHORTCUT
 Shortcut=Meta+Shift+T
 
-[Data_1/Triggers/2]
+[Data_3]
+Comment=Enable Bismuth free mode
+Enabled=true
+Name=Bismuth Free
+Type=GENERIC
+
+[Data_3/Actions]
+ActionsCount=1
+
+[Data_3/Actions/0]
+Type=COMMAND_URL
+CommandURL=~/scripts/toggle_tiling.sh --free
+
+[Data_3/Triggers]
+TriggersCount=1
+
+[Data_3/Triggers/0]
 Type=SHORTCUT
 Shortcut=Meta+Alt+T

--- a/scripts/apply_bismuth_mode.sh
+++ b/scripts/apply_bismuth_mode.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Apply previously saved Bismuth mode on login.
+
+set -euo pipefail
+
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}"
+STATE_FILE="$STATE_DIR/bismuth_mode"
+
+if [[ -f "$STATE_FILE" ]]; then
+    mode=$(<"$STATE_FILE")
+    "$HOME"/scripts/toggle_tiling.sh --"$mode"
+fi

--- a/scripts/toggle_tiling.sh
+++ b/scripts/toggle_tiling.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Toggle Bismuth tiling in KDE and record current mode.
-# Writes either "tiling" or "floating" to a state file.
+# Writes either "grid" or "free" to a state file.
+# Accepts `--grid` or `--free` to force a mode without toggling.
 
 set -euo pipefail
 
@@ -9,12 +10,22 @@ STATE_FILE="$STATE_DIR/bismuth_mode"
 
 mkdir -p "$STATE_DIR"
 
-if qdbus org.kde.KWin /Scripting org.kde.KWin.Scripting.isScriptLoaded bismuth &>/dev/null; then
-    qdbus org.kde.KWin /Scripting org.kde.KWin.Scripting.unloadScript bismuth >/dev/null
-    MODE="floating"
-else
+force="${1:-}"
+
+if [[ "$force" == "--grid" ]]; then
     qdbus org.kde.KWin /Scripting org.kde.KWin.Scripting.loadScript bismuth >/dev/null
-    MODE="tiling"
+    MODE="grid"
+elif [[ "$force" == "--free" ]]; then
+    qdbus org.kde.KWin /Scripting org.kde.KWin.Scripting.unloadScript bismuth >/dev/null
+    MODE="free"
+else
+    if qdbus org.kde.KWin /Scripting org.kde.KWin.Scripting.isScriptLoaded bismuth &>/dev/null; then
+        qdbus org.kde.KWin /Scripting org.kde.KWin.Scripting.unloadScript bismuth >/dev/null
+        MODE="free"
+    else
+        qdbus org.kde.KWin /Scripting org.kde.KWin.Scripting.loadScript bismuth >/dev/null
+        MODE="grid"
+    fi
 fi
 
 echo "$MODE" > "$STATE_FILE"


### PR DESCRIPTION
## Summary
- allow `toggle_tiling.sh` to force grid or free modes and record selection
- add systemd service to reapply saved Bismuth mode at login
- wire KDE hotkeys to call the script with `--grid` or `--free`

## Testing
- `bash -n scripts/toggle_tiling.sh`
- `bash -n scripts/apply_bismuth_mode.sh`
- `systemd-analyze verify cyberplasma/systemd/user/bismuth-mode.service` *(fails: Command /root/scripts/apply_bismuth_mode.sh is not executable: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a3eea5a6448325acb5e81d1ed6e11d