### PR TITLE
Support multi-screen Eww geometry

### DIFF
--- a/cyberplasma/eww/config.yuck
+++ b/cyberplasma/eww/config.yuck
@@ -11,12 +11,21 @@
 ;; Expose widgets as windows
 (defwindow top_bar
   :focusable false
+  :wm-ignore true
+  :stacking "overlay"
+  :geometry (geometry :anchor "top left" :x "0px" :y "0px" :width "100%" :height "30px")
   (top_bar))
 
 (defwindow left_column
   :focusable false
+  :wm-ignore true
+  :stacking "overlay"
+  :geometry (geometry :anchor "left center" :x "0px" :y "0px" :width "220px" :height "100%")
   (left_column))
 
 (defwindow mpris_controls
   :focusable false
+  :wm-ignore true
+  :stacking "overlay"
+  :geometry (geometry :anchor "center" :x "0px" :y "0px" :width "300px" :height "60px")
   (mpris_controls))

--- a/cyberplasma/eww/widgets/left_column.yuck
+++ b/cyberplasma/eww/widgets/left_column.yuck
@@ -2,7 +2,7 @@
 (defpoll net :interval "2s" :command "../scripts/net.sh eth0" :json true)
 
 (defwidget left_column []
-  (box :class "left-column" :orientation "v" :spacing 8
+  (box :class "left-column" :orientation "v" :spacing 8 :vexpand true
        (label :class "net-rx" :text "Rx ${net.rx_bytes}")
        (label :class "net-tx" :text "Tx ${net.tx_bytes}")
        (mpris_controls)))

--- a/cyberplasma/eww/widgets/top_bar.yuck
+++ b/cyberplasma/eww/widgets/top_bar.yuck
@@ -3,6 +3,6 @@
 (defpoll ram :interval "5s" :command "../scripts/ram.sh" :json true)
 
 (defwidget top_bar []
-  (box :class "top-bar" :space-evenly true
+  (box :class "top-bar" :space-evenly true :hexpand true
        (label :class "cpu" :text "${cpu.usage}%")
        (label :class "ram" :text "${ram.percent}%")))

--- a/cyberplasma/scripts/launch-eww.sh
+++ b/cyberplasma/scripts/launch-eww.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Launch Eww widgets for each connected monitor using --screen.
+# Determines monitor geometry via xrandr.
+set -euo pipefail
+
+# Start the daemon if not already running
+if ! eww ping >/dev/null 2>&1; then
+  eww daemon
+  # Give the daemon a moment to initialise
+  sleep 0.2
+fi
+
+# Parse connected monitors and their geometry
+xrandr --query | awk '/ connected/{print $1, $3}' | while read -r name geometry; do
+  # Extract width, height and offsets from the geometry string: 1920x1080+0+0
+  width=${geometry%%x*}
+  rest=${geometry#*x}
+  height=${rest%%+*}
+  offset_x=${rest#*+}
+  offset_y=${offset_x#*+}
+  offset_x=${offset_x%%+*}
+
+  # Open widgets on the given monitor. Geometry inside config.yuck
+  # is relative to the screen, so the coordinates computed above are
+  # primarily informational and available for potential future use.
+  eww open top_bar --screen "$name"
+  eww open left_column --screen "$name"
+done
+
+# Optionally open standalone mpris controls on the primary monitor
+# only if desired by users of this script. Commented out by default.
+# eww open mpris_controls --screen "$(xrandr --query | awk '/ primary/{print $1}')"
+

--- a/cyberplasma/systemd/user/eww.service
+++ b/cyberplasma/systemd/user/eww.service
@@ -8,8 +8,7 @@ After=graphical-session.target
 
 [Service]
 ExecStart=eww daemon
-ExecStartPost=eww open top_bar
-ExecStartPost=eww open left_column
+ExecStartPost=../../../cyberplasma/scripts/launch-eww.sh
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
## Summary
- add explicit window geometries that honor `--screen` and remain click-through
- expand widgets to fill configured geometry
- script monitors with `xrandr` and open widgets per screen
- systemd service launches widgets via helper script

## Testing
- `bash -n cyberplasma/scripts/launch-eww.sh`
- `./cyberplasma/scripts/launch-eww.sh` *(fails: eww: command not found)*
- `xrandr --query` *(command not found)*
- `sudo apt-get update` *(403 errors)*
- `sudo apt-get install -y x11-xserver-utils` *(unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a3fe6de29c83259afaf90809c28926