### PR TITLE
Add script to toggle Plasma panel visibility by screen

### DIFF
--- a/cyberplasma/systemd/user/README.md
+++ b/cyberplasma/systemd/user/README.md
@@ -28,3 +28,24 @@ systemctl --user enable --now cyberplasma.target
 ```
 
 This will pull in the individual services via `WantedBy=cyberplasma.target`.
+
+## Plasma Panel Setup
+The tiling toggle integrates with a helper script that can hide a
+Plasma panel on a specific screen when entering **Command Mode** and
+show it again for **Control Mode**.  Determine the screen ID of the
+panel you want managed:
+
+```bash
+qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.panelIds
+qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript 'panelById(PANEL_ID).screen'
+```
+
+Export `CYBERPLASMA_PANEL_SCREEN_ID` with the desired screen number so
+`toggle_tiling.sh` knows which panel to control.
+
+```bash
+export CYBERPLASMA_PANEL_SCREEN_ID=1
+```
+
+Copy the `panel_visibility.sh` script to `~/scripts/` if it is not
+already present.

--- a/scripts/panel_visibility.sh
+++ b/scripts/panel_visibility.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Show or hide a Plasma panel on a given screen using DBus.
+# Usage: panel_visibility.sh [show|hide] <screen-id>
+
+set -euo pipefail
+
+action="${1:-}"
+screen="${2:-}"
+
+if [[ -z "$action" || -z "$screen" ]]; then
+    echo "Usage: $0 [show|hide] <screen-id>" >&2
+    exit 1
+fi
+
+if [[ "$action" != "show" && "$action" != "hide" ]]; then
+    echo "Action must be 'show' or 'hide'" >&2
+    exit 1
+fi
+
+script="
+const ids = panelIds;
+for (var i = 0; i < ids.length; ++i) {
+  var p = panelById(ids[i]);
+  if (p.screen === $screen) {
+    if ('$action' === 'hide') {
+      p.hiding = 'autohide';
+      p.hide();
+    } else {
+      p.hiding = 'none';
+      p.show();
+    }
+  }
+}
+"
+
+qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript "$script"

--- a/scripts/toggle_tiling.sh
+++ b/scripts/toggle_tiling.sh
@@ -29,3 +29,17 @@ else
 fi
 
 echo "$MODE" > "$STATE_FILE"
+
+# Optionally toggle a Plasma panel on a specific screen.  The
+# CYBERPLASMA_PANEL_SCREEN_ID environment variable selects which
+# screen's panel should respond when modes change.  When switching to
+# Command Mode ("grid") the panel is hidden; returning to Control Mode
+# ("free") shows it again.
+panel_screen="${CYBERPLASMA_PANEL_SCREEN_ID:-}"
+if [[ -n "$panel_screen" ]]; then
+    if [[ "$MODE" == "grid" ]]; then
+        "$HOME"/scripts/panel_visibility.sh hide "$panel_screen"
+    else
+        "$HOME"/scripts/panel_visibility.sh show "$panel_screen"
+    fi
+fi


### PR DESCRIPTION
## Summary
- add `panel_visibility.sh` script to show or hide Plasma panels via DBus
- integrate panel visibility control into tiling mode toggler
- document required panel IDs and environment variable setup

## Testing
- `bash -n scripts/panel_visibility.sh scripts/toggle_tiling.sh`
- `shellcheck scripts/panel_visibility.sh scripts/toggle_tiling.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3fe6e9fbc8325b9f0c056a5235186