### PR TITLE
feat: add HUD layout presets and hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Use the following shortcuts to switch between modes:
 - `Meta+G` toggles **GridMode**.
 - `Meta+F` toggles **FreeMode**.
 - `Meta+T`, `Meta+Shift+T`, and `Meta+Alt+T` toggle Bismuth tiling on or off.
+- `Meta+F6` cycles forward through HUD layout presets.
+- `Meta+F7` cycles backward through HUD layout presets.
+- `Meta+Alt+Arrow` keys nudge HUD blocks and persist the new layout.
 
 ### Persistence
 The current mode is remembered and restored on login so your preferred layout

--- a/kde/khotkeysrc
+++ b/kde/khotkeysrc
@@ -3,7 +3,7 @@
 
 [Main]
 Version=3
-DataCount=3
+DataCount=9
 
 [Data_1]
 Comment=Toggle Bismuth tiling
@@ -64,3 +64,123 @@ TriggersCount=1
 [Data_3/Triggers/0]
 Type=SHORTCUT
 Shortcut=Meta+Alt+T
+
+[Data_4]
+Comment=Cycle HUD presets forward
+Enabled=true
+Name=HUD Preset Next
+Type=GENERIC
+
+[Data_4/Actions]
+ActionsCount=1
+
+[Data_4/Actions/0]
+Type=COMMAND_URL
+CommandURL=~/scripts/cp_layouts.py cycle next
+
+[Data_4/Triggers]
+TriggersCount=1
+
+[Data_4/Triggers/0]
+Type=SHORTCUT
+Shortcut=Meta+F6
+
+[Data_5]
+Comment=Cycle HUD presets backward
+Enabled=true
+Name=HUD Preset Previous
+Type=GENERIC
+
+[Data_5/Actions]
+ActionsCount=1
+
+[Data_5/Actions/0]
+Type=COMMAND_URL
+CommandURL=~/scripts/cp_layouts.py cycle prev
+
+[Data_5/Triggers]
+TriggersCount=1
+
+[Data_5/Triggers/0]
+Type=SHORTCUT
+Shortcut=Meta+F7
+
+[Data_6]
+Comment=Move HUD up
+Enabled=true
+Name=HUD Move Up
+Type=GENERIC
+
+[Data_6/Actions]
+ActionsCount=1
+
+[Data_6/Actions/0]
+Type=COMMAND_URL
+CommandURL=~/scripts/cp_layouts.py move up
+
+[Data_6/Triggers]
+TriggersCount=1
+
+[Data_6/Triggers/0]
+Type=SHORTCUT
+Shortcut=Meta+Alt+Up
+
+[Data_7]
+Comment=Move HUD down
+Enabled=true
+Name=HUD Move Down
+Type=GENERIC
+
+[Data_7/Actions]
+ActionsCount=1
+
+[Data_7/Actions/0]
+Type=COMMAND_URL
+CommandURL=~/scripts/cp_layouts.py move down
+
+[Data_7/Triggers]
+TriggersCount=1
+
+[Data_7/Triggers/0]
+Type=SHORTCUT
+Shortcut=Meta+Alt+Down
+
+[Data_8]
+Comment=Move HUD left
+Enabled=true
+Name=HUD Move Left
+Type=GENERIC
+
+[Data_8/Actions]
+ActionsCount=1
+
+[Data_8/Actions/0]
+Type=COMMAND_URL
+CommandURL=~/scripts/cp_layouts.py move left
+
+[Data_8/Triggers]
+TriggersCount=1
+
+[Data_8/Triggers/0]
+Type=SHORTCUT
+Shortcut=Meta+Alt+Left
+
+[Data_9]
+Comment=Move HUD right
+Enabled=true
+Name=HUD Move Right
+Type=GENERIC
+
+[Data_9/Actions]
+ActionsCount=1
+
+[Data_9/Actions/0]
+Type=COMMAND_URL
+CommandURL=~/scripts/cp_layouts.py move right
+
+[Data_9/Triggers]
+TriggersCount=1
+
+[Data_9/Triggers/0]
+Type=SHORTCUT
+Shortcut=Meta+Alt+Right

--- a/scripts/cp_layouts.py
+++ b/scripts/cp_layouts.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Manage CyberPlasma HUD layouts.
+
+Layouts are stored in ``~/.local/state/cp_layouts.json`` and are keyed by
+``<screen>_<mode>``. Each entry contains the currently selected preset index and
+an array of presets. A preset is a mapping of widget name to ``{"x": int,
+"y": int}`` coordinates.
+
+This script provides two subcommands:
+
+``cycle <next|prev>``
+    Switch to the next or previous layout preset for the current screen/mode.
+
+``move <direction>``
+    Offset all widget coordinates in the current preset. Direction may be
+    ``left``, ``right``, ``up`` or ``down``.
+
+The script intentionally keeps interaction with the window manager minimal. It
+only reads/writes the layout JSON file. Integrations with external tools such as
+``eww`` can build on top of this state file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from typing import Dict, Any
+
+STATE_DIR = os.environ.get("XDG_STATE_HOME", os.path.expanduser("~/.local/state"))
+LAYOUT_FILE = os.path.join(STATE_DIR, "cp_layouts.json")
+MODE_FILE = os.path.join(STATE_DIR, "bismuth_mode")
+STEP = 25  # pixels to move widgets per arrow press
+
+
+def load_data() -> Dict[str, Any]:
+    try:
+        with open(LAYOUT_FILE) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {}
+
+
+def save_data(data: Dict[str, Any]) -> None:
+    os.makedirs(STATE_DIR, exist_ok=True)
+    with open(LAYOUT_FILE, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def current_screen() -> str:
+    """Return the name of the primary screen.
+
+    Falls back to ``unknown`` if ``xrandr`` is not available.
+    """
+
+    try:
+        output = subprocess.check_output(["xrandr", "--current"], text=True)
+    except Exception:
+        return "unknown"
+
+    for line in output.splitlines():
+        if " connected" in line:
+            return line.split()[0]
+    return "unknown"
+
+
+def current_mode() -> str:
+    try:
+        with open(MODE_FILE) as f:
+            return f.read().strip() or "default"
+    except FileNotFoundError:
+        return "default"
+
+
+def current_key() -> str:
+    return f"{current_screen()}_{current_mode()}"
+
+
+def cycle(direction: str) -> None:
+    data = load_data()
+    key = current_key()
+    entry = data.setdefault(key, {"current": 0, "presets": [{}]})
+    presets = entry["presets"]
+    idx = entry.get("current", 0)
+    if direction == "next":
+        idx = (idx + 1) % len(presets)
+    else:
+        idx = (idx - 1) % len(presets)
+    entry["current"] = idx
+    save_data(data)
+
+
+def move(direction: str) -> None:
+    data = load_data()
+    key = current_key()
+    entry = data.setdefault(key, {"current": 0, "presets": [{}]})
+    preset = entry["presets"][entry["current"]]
+    dx = dy = 0
+    if direction == "left":
+        dx = -STEP
+    elif direction == "right":
+        dx = STEP
+    elif direction == "up":
+        dy = -STEP
+    elif direction == "down":
+        dy = STEP
+    for widget, pos in preset.items():
+        pos["x"] = pos.get("x", 0) + dx
+        pos["y"] = pos.get("y", 0) + dy
+    save_data(data)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(__doc__)
+        return 1
+
+    cmd = argv[1]
+    if cmd == "cycle" and len(argv) >= 3:
+        if argv[2] in {"next", "prev"}:
+            cycle(argv[2])
+            return 0
+    elif cmd == "move" and len(argv) >= 3:
+        if argv[2] in {"left", "right", "up", "down"}:
+            move(argv[2])
+            return 0
+
+    print(__doc__)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary
- implement cp_layouts.py to persist HUD widget positions per screen/mode
- bind Meta+F6/F7 to cycle presets and Meta+Alt+Arrow to move HUD blocks
- document new HUD layout controls in README

## Testing
- `python scripts/cp_layouts.py cycle next`
- `python scripts/cp_layouts.py move up`
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile scripts/cp_layouts.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3fe6f2dcc832585a4f74941f28598