### PR TITLE
Add KWin window rules and Bismuth float exclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,22 @@ To keep certain applications in FreeMode even when GridMode is active, create a
 window rule under *System Settings → Window Management → Window Rules* and set
 tiling to **Off** for that app.
 
+### KWin Window Rules
+The repository ships with rules to keep EWW widgets and the GLava visualizer on top, out of the taskbar and unfocusable.
+Apply them by copying the file:
+```bash
+cp kde/kwinrulesrc ~/.config/kwinrulesrc
+```
+If you already maintain your own rules, import and merge via *System Settings → Window Management → Window Rules*.
+
+### Floating exceptions
+Bismuth's `bismuth/config.json` marks media players, Steam, and game executables so they float in Command Mode. Install it with:
+```bash
+mkdir -p ~/.config/bismuth
+cp bismuth/config.json ~/.config/bismuth/
+```
+
+
 ## Screenshot
 A preview of the CyberPlasma setup:
 

--- a/bismuth/config.json
+++ b/bismuth/config.json
@@ -7,8 +7,9 @@
     { "class": "mpv" },
     { "class": "vlc" },
     { "class": "steam" },
-    { "class": "kdenlive" },
     { "class": "^steam_app.*" },
-    { "class": "^[Ww]ine$" }
+    { "class": "gamescope" },
+    { "class": "^[Ww]ine$" },
+    { "class": "kdenlive" }
   ]
 }

--- a/kde/kwinrulesrc
+++ b/kde/kwinrulesrc
@@ -1,0 +1,24 @@
+[General]
+count=2
+
+[1]
+Description=EWW Widgets
+wmclass=eww
+wmclassmatch=1
+above=true
+aboverule=2
+skiptaskbar=true
+skiptaskbarrule=2
+nofocus=true
+nofocusrule=2
+
+[2]
+Description=GLava Visualizer
+wmclass=glava
+wmclassmatch=1
+above=true
+aboverule=2
+skiptaskbar=true
+skiptaskbarrule=2
+nofocus=true
+nofocusrule=2


### PR DESCRIPTION
## Summary
- Add KWin window rules keeping EWW and GLava above other windows, out of the taskbar, and unfocusable.
- Extend Bismuth float filter with gamescope and document mpv, vlc, steam, and other game windows to float in Command Mode.
- Document setup instructions for KWin rules and floating exclusions in the README.

## Testing
- `jq '.' bismuth/config.json`


------
https://chatgpt.com/codex/tasks/task_e_68a3fe70c6d0832585ee337fdfc52876