### PR TITLE
Harden scripts and add shellcheck CI

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,21 @@
+name: Shellcheck
+
+on:
+  push:
+    paths:
+      - 'cyberplasma/scripts/*.sh'
+      - '.github/workflows/shellcheck.yml'
+  pull_request:
+    paths:
+      - 'cyberplasma/scripts/*.sh'
+      - '.github/workflows/shellcheck.yml'
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Run shellcheck
+        run: shellcheck cyberplasma/scripts/*.sh

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Cyberpunk-themed Plasma KDE rice kit. Main color theme right now is purple/cyan/
 - Git for cloning the repository
 - (Optional) [EWW](https://elkowar.github.io/eww/) for widget customization
 
+## Security
+All helper scripts in `cyberplasma/scripts` are POSIX-compliant and run without elevated privileges. Inputs are sanitized, and network requests include fixed timeouts. The project operates entirely in user space without requiring escalated permissions. Continuous integration runs ShellCheck to maintain script quality.
+
 ## Installation
 
 ### Window Decorations

--- a/cyberplasma/scripts/cpu.sh
+++ b/cyberplasma/scripts/cpu.sh
@@ -1,13 +1,13 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Output CPU usage percentage as JSON.
 # Avoids elevated privileges and ensures sanitized output.
-set -euo pipefail
+set -eu
 
 read -r _ user nice system idle iowait irq softirq steal guest < /proc/stat
 prev_total=$((user + nice + system + idle + iowait + irq + softirq + steal))
 prev_idle=$((idle + iowait))
 
-sleep 0.2
+sleep 1
 
 read -r _ user nice system idle iowait irq softirq steal guest < /proc/stat
 total=$((user + nice + system + idle + iowait + irq + softirq + steal))

--- a/cyberplasma/scripts/local_ip.sh
+++ b/cyberplasma/scripts/local_ip.sh
@@ -1,15 +1,15 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Output IPv4 addresses for non-loopback interfaces as JSON.
 # Avoids elevated privileges and ensures sanitized output.
-set -euo pipefail
+set -eu
 
 printf '{'
 first=1
-while IFS=' ' read -r num iface fam addr _; do
-  ip=${addr%/*}
+ip -o -4 addr show scope global 2>/dev/null | while IFS=' ' read -r num iface fam addr _; do
+  ip_addr=${addr%/*}
   iface_sanitized=$(printf '%s' "$iface" | tr -cd 'A-Za-z0-9_-')
-  if [ $first -eq 0 ]; then printf ','; fi
-  printf '"%s":"%s"' "$iface_sanitized" "$ip"
+  if [ "$first" -eq 0 ]; then printf ','; fi
+  printf '"%s":"%s"' "$iface_sanitized" "$ip_addr"
   first=0
-done < <(ip -o -4 addr show scope global 2>/dev/null)
+done
 printf '}\n'

--- a/cyberplasma/scripts/mpris.sh
+++ b/cyberplasma/scripts/mpris.sh
@@ -1,15 +1,15 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Output current MPRIS metadata as JSON.
 # Avoids elevated privileges and ensures sanitized output.
-set -euo pipefail
+set -eu
 
 if ! command -v playerctl >/dev/null 2>&1; then
   printf '{"status":"unavailable"}\n'
   exit 0
 fi
 
-player=$(playerctl -l 2>/dev/null | head -n1)
-if [[ -z "$player" ]]; then
+player=$(playerctl -l 2>/dev/null | head -n1 || true)
+if [ -z "$player" ]; then
   printf '{"status":"stopped"}\n'
   exit 0
 fi
@@ -17,7 +17,7 @@ fi
 format='{"title":"{{escape .Title}}","artist":"{{escape (join .Artist ", ")}}","status":"{{lc .Status}}"}'
 metadata=$(playerctl metadata --format "$format" 2>/dev/null || true)
 
-if [[ -n "$metadata" ]]; then
+if [ -n "$metadata" ]; then
   printf '%s\n' "$metadata"
 else
   printf '{"status":"stopped"}\n'

--- a/cyberplasma/scripts/net.sh
+++ b/cyberplasma/scripts/net.sh
@@ -1,32 +1,34 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Output network transfer rate in kB/s for an interface as JSON.
 # Usage: net.sh <interface>
 # Ensures input sanitization and avoids elevated privileges.
-set -euo pipefail
+set -eu
 
-if [[ $# -ne 1 ]]; then
+if [ $# -ne 1 ]; then
   printf 'Usage: %s <interface>\n' "$(basename "$0")" >&2
   exit 1
 fi
-iface="$1"
+iface=$1
 # Allow only alphanumeric, hyphen, and underscore in interface name.
-if [[ ! "$iface" =~ ^[A-Za-z0-9_-]+$ ]]; then
-  printf 'Invalid interface name\n' >&2
-  exit 1
-fi
+case "$iface" in
+  *[!A-Za-z0-9_-]*|'')
+    printf 'Invalid interface name\n' >&2
+    exit 1
+    ;;
+esac
 
 rx_path="/sys/class/net/$iface/statistics/rx_bytes"
 tx_path="/sys/class/net/$iface/statistics/tx_bytes"
-if [[ ! -r "$rx_path" || ! -r "$tx_path" ]]; then
+if [ ! -r "$rx_path" ] || [ ! -r "$tx_path" ]; then
   printf 'Interface not found\n' >&2
   exit 1
 fi
 
-rx1=$(<"$rx_path")
-tx1=$(<"$tx_path")
+rx1=$(cat "$rx_path")
+tx1=$(cat "$tx_path")
 sleep 1
-rx2=$(<"$rx_path")
-tx2=$(<"$tx_path")
+rx2=$(cat "$rx_path")
+tx2=$(cat "$tx_path")
 
 rx_rate=$(awk -v r1="$rx1" -v r2="$rx2" 'BEGIN {printf "%.2f", (r2 - r1)/1024}')
 tx_rate=$(awk -v t1="$tx1" -v t2="$tx2" 'BEGIN {printf "%.2f", (t2 - t1)/1024}')

--- a/cyberplasma/scripts/public_ip.sh
+++ b/cyberplasma/scripts/public_ip.sh
@@ -1,10 +1,10 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Output the current public IPv4 address as JSON.
 # Avoids elevated privileges and ensures sanitized output.
-set -euo pipefail
+set -eu
 
-ip=$(curl -fsS https://api.ipify.org 2>/dev/null || true)
-if [[ "$ip" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
+ip=$(curl --max-time 5 -fsS https://api.ipify.org 2>/dev/null || true)
+if printf '%s' "$ip" | grep -Eq '^([0-9]{1,3}\.){3}[0-9]{1,3}$'; then
   printf '{"ip":"%s"}\n' "$ip"
 else
   printf '{"ip":null}\n'

--- a/cyberplasma/scripts/ram.sh
+++ b/cyberplasma/scripts/ram.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Output RAM usage as JSON.
 # Avoids elevated privileges and ensures sanitized output.
-set -euo pipefail
+set -eu
 
 meminfo=/proc/meminfo
 total=$(awk '/^MemTotal:/ {print $2}' "$meminfo")

--- a/cyberplasma/scripts/temp.sh
+++ b/cyberplasma/scripts/temp.sh
@@ -1,18 +1,20 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Output temperatures from thermal zones in Celsius as JSON.
 # Avoids elevated privileges and ensures sanitized output.
-set -euo pipefail
+set -eu
 
 printf '{'
 first=1
 for zone in /sys/class/thermal/thermal_zone*/temp; do
   [ -r "$zone" ] || continue
-  zone_dir="${zone%/temp}"
+  zone_dir=${zone%/temp}
   name=$(tr -cd 'A-Za-z0-9_-' < "$zone_dir/type")
   temp_raw=$(cat "$zone")
-  [[ "$temp_raw" =~ ^[0-9]+$ ]] || continue
+  case "$temp_raw" in
+    *[!0-9]*|'') continue ;;
+  esac
   temp_c=$(awk -v t="$temp_raw" 'BEGIN { printf "%.1f", t/1000 }')
-  if [ $first -eq 0 ]; then printf ','; fi
+  if [ "$first" -eq 0 ]; then printf ','; fi
   printf '"%s":%s' "$name" "$temp_c"
   first=0
 done

--- a/cyberplasma/scripts/top_procs.sh
+++ b/cyberplasma/scripts/top_procs.sh
@@ -1,12 +1,12 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Output top processes by CPU usage as a JSON array.
 # Avoids elevated privileges and ensures sanitized output.
-set -euo pipefail
+set -eu
 
 count=${1:-5}
-if [[ ! "$count" =~ ^[0-9]+$ ]]; then
-  count=5
-fi
+case "$count" in
+  *[!0-9]*|'') count=5 ;;
+esac
 
 printf '['
 first=1
@@ -14,7 +14,7 @@ ps -eo pid,comm,%cpu --no-headers | sort -k3 -nr | head -n "$count" |
 while read -r pid comm cpu; do
   comm_clean=$(printf '%s' "$comm" | tr -cd 'A-Za-z0-9_.-')
   cpu_fmt=$(awk -v c="$cpu" 'BEGIN{printf "%.2f", c}')
-  if [ $first -eq 0 ]; then printf ','; fi
+  if [ "$first" -eq 0 ]; then printf ','; fi
   printf '{"pid":%s,"cmd":"%s","cpu":%s}' "$pid" "$comm_clean" "$cpu_fmt"
   first=0
 done

--- a/cyberplasma/scripts/vpn.sh
+++ b/cyberplasma/scripts/vpn.sh
@@ -1,18 +1,20 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Output whether a VPN interface appears active as JSON.
 # Avoids elevated privileges and ensures sanitized output.
-set -euo pipefail
+set -eu
 
 vpn=false
 for iface in /sys/class/net/*; do
   name=$(basename "$iface")
-  if [[ "$name" =~ ^(tun|tap|wg|ppp)[A-Za-z0-9_-]*$ ]]; then
-    state=$(cat "$iface/operstate" 2>/dev/null)
-    if [[ "$state" == "up" ]]; then
-      vpn=true
-      break
-    fi
-  fi
+  case "$name" in
+    tun*|tap*|wg*|ppp*)
+      state=$(cat "$iface/operstate" 2>/dev/null)
+      if [ "$state" = "up" ]; then
+        vpn=true
+        break
+      fi
+      ;;
+  esac
 done
 
 printf '{"vpn":%s}\n' "$vpn"


### PR DESCRIPTION
## Summary
- Rewrite `cyberplasma/scripts` shell scripts for POSIX `sh` compliance and safer parameter handling
- Add `curl --max-time` and sanitize network interface names to avoid hangs and injection
- Introduce GitHub Action running ShellCheck to catch script issues
- Document security model and permissions in README

## Testing
- `cyberplasma/scripts/cpu.sh`
- `cyberplasma/scripts/local_ip.sh`
- `cyberplasma/scripts/mpris.sh`
- `cyberplasma/scripts/net.sh lo`
- `cyberplasma/scripts/public_ip.sh`
- `cyberplasma/scripts/ram.sh`
- `cyberplasma/scripts/temp.sh`
- `cyberplasma/scripts/top_procs.sh 2`
- `cyberplasma/scripts/vpn.sh`
- `shellcheck cyberplasma/scripts/*.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3fe719e408325a341fb3aae27d210