### PR TITLE
Integrate comprehensive system metrics into Eww widgets

### DIFF
--- a/cyberplasma/eww/widgets/left_column.yuck
+++ b/cyberplasma/eww/widgets/left_column.yuck
@@ -1,8 +1,27 @@
-;; Left column widget with network metrics and media controls
-(defpoll net :interval "2s" :command "../scripts/net.sh eth0" :json true)
+;; Left column widget with system gauges, network metrics, and top processes
+
+;; System gauges
+(defpoll cpu :interval "1s" :command "../scripts/cpu.sh" :json true)
+(defpoll ram :interval "5s" :command "../scripts/ram.sh" :json true)
+(defpoll temp :interval "5s" :command "../scripts/temp.sh | jq '{temp: (.[keys[0]])}'" :json true)
+
+;; Network rates using dynamically detected interface
+(defpoll net :interval "2s" :command "../scripts/net.sh $(../scripts/default_iface.sh)" :json true)
+
+;; Top processes
+(defpoll top_procs :interval "10s" :command "../scripts/top_procs.sh" :json true)
 
 (defwidget left_column []
   (box :class "left-column" :orientation "v" :spacing 8 :vexpand true
-       (label :class "net-rx" :text "Rx ${net.rx_bytes}")
-       (label :class "net-tx" :text "Tx ${net.tx_bytes}")
-       (mpris_controls)))
+       ;; Gauges
+       (progress :class "cpu" :value cpu.usage :max 100)
+       (progress :class "ram" :value ram.percent :max 100)
+       (progress :class "temp" :value temp.temp :max 100)
+       ;; Network metrics
+       (box :class "net" :spacing 4
+            (label :class "net-rx" :text "Rx ${net.rx_kBps} kB/s")
+            (label :class "net-tx" :text "Tx ${net.tx_kBps} kB/s"))
+       ;; Top processes by CPU
+       (box :class "procs" :orientation "v"
+            (for proc top_procs
+                 (label :class "proc" :text "${proc.cmd} ${proc.cpu}%")))))

--- a/cyberplasma/eww/widgets/top_bar.yuck
+++ b/cyberplasma/eww/widgets/top_bar.yuck
@@ -1,8 +1,37 @@
-;; Top bar widget with CPU and RAM metrics
+;; Top bar widget with time, system metrics, network, IP info, and media controls
+;; Time and date
+(defpoll datetime :interval "1s" :command "date +'%Y-%m-%d %H:%M:%S'")
+
+;; System gauges
 (defpoll cpu :interval "1s" :command "../scripts/cpu.sh" :json true)
 (defpoll ram :interval "5s" :command "../scripts/ram.sh" :json true)
+(defpoll temp :interval "5s" :command "../scripts/temp.sh | jq '{temp: (.[keys[0]])}'" :json true)
+
+;; Network rates and IP information
+(defpoll net :interval "2s" :command "../scripts/net.sh $(../scripts/default_iface.sh)" :json true)
+(defpoll vpn :interval "10s" :command "../scripts/vpn.sh" :json true)
+(defpoll local_ip :interval "60s" :command "../scripts/local_ip.sh" :json true)
+(defpoll public_ip :interval "60s" :command "../scripts/public_ip.sh" :json true)
+
+;; Media info
+(defpoll mpris :interval "2s" :command "../scripts/mpris.sh" :json true)
 
 (defwidget top_bar []
   (box :class "top-bar" :space-evenly true :hexpand true
-       (label :class "cpu" :text "${cpu.usage}%")
-       (label :class "ram" :text "${ram.percent}%")))
+       ;; Time/Date
+       (label :class "datetime" :text "${datetime}")
+       ;; Gauges
+       (progress :class "cpu" :value cpu.usage :max 100)
+       (progress :class "ram" :value ram.percent :max 100)
+       (progress :class "temp" :value temp.temp :max 100)
+       ;; Network rates
+       (label :class "net-rx" :text "Rx ${net.rx_kBps} kB/s")
+       (label :class "net-tx" :text "Tx ${net.tx_kBps} kB/s")
+       ;; IP information
+       (label :class "vpn" :text "VPN ${vpn.vpn}")
+       (label :class "local-ip" :text "${local_ip[net.interface]}")
+       (label :class "public-ip" :text "${public_ip.ip}")
+       ;; Now playing with controls
+       (box :class "mpris" :spacing 4
+            (label :class "mpris-text" :text "${mpris.artist} - ${mpris.title}")
+            (mpris_controls))))

--- a/cyberplasma/scripts/default_iface.sh
+++ b/cyberplasma/scripts/default_iface.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Output default network interface used for outbound connections.
+# Avoids elevated privileges and ensures sanitized output.
+set -eu
+ip route get 1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i=="dev"){print $(i+1); exit}}'
+


### PR DESCRIPTION
## Summary
- Expand `top_bar.yuck` with time/date, system gauges, network rates, IP info, and MPRIS now-playing controls
- Replace hard-coded interface usage in widgets with dynamic detection via new `default_iface.sh`
- Revamp `left_column.yuck` to include gauges, network throughput and top processes

## Testing
- `shellcheck cyberplasma/scripts/default_iface.sh` *(fails: command not found)*
- `sh -n cyberplasma/scripts/default_iface.sh`
- `eww --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a420d81a648325ab50354fc37682a5