### PR TITLE
feat: add screen modes service

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ An EWW configuration will be provided in a future update. Once available:
    eww open left_column
    ```
 
+### Screen Modes
+Restore saved display configurations at login by enabling the user service:
+
+```bash
+systemctl --user enable --now screen-modes.service
+```
+
 ## GridMode and FreeMode
 CyberPlasma leverages KWin's tiling system and provides two layouts:
 

--- a/cyberplasma/systemd/user/README.md
+++ b/cyberplasma/systemd/user/README.md
@@ -8,6 +8,7 @@ These units manage optional components for the CyberPlasma setup.
 - `glava.service` – starts the GLava audio visualizer.
 - `yakuake.service` – runs the Yakuake drop-down terminal.
 - `bismuth-mode.service` – restores the last Bismuth tiling mode on login.
+- `screen-modes.service` – applies saved screen modes on login.
 
 ## Dependencies
 - `eww` for `eww.service`

--- a/cyberplasma/systemd/user/screen-modes.service
+++ b/cyberplasma/systemd/user/screen-modes.service
@@ -1,0 +1,12 @@
+# Apply saved screen modes at login.
+# Runs the apply_screen_modes script if modes are saved.
+
+[Unit]
+Description=Apply saved screen modes
+After=graphical-session.target
+
+[Service]
+ExecStart=%h/scripts/apply_screen_modes.sh
+
+[Install]
+WantedBy=cyberplasma.target


### PR DESCRIPTION
## Summary
- add screen-modes systemd user unit to restore saved display configuration
- document enabling the screen-modes service

## Testing
- `systemd-analyze verify cyberplasma/systemd/user/screen-modes.service` *(fails: Command /root/scripts/apply_screen_modes.sh is not executable: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a420e6db048325b33668663cf7f248