### PR TITLE
Cache public IP for 60s and validate response

### DIFF
--- a/cyberplasma/scripts/public_ip.sh
+++ b/cyberplasma/scripts/public_ip.sh
@@ -3,9 +3,37 @@
 # Avoids elevated privileges and ensures sanitized output.
 set -eu
 
-ip=$(curl --max-time 5 -fsS https://api.ipify.org 2>/dev/null || true)
-if printf '%s' "$ip" | grep -Eq '^([0-9]{1,3}\.){3}[0-9]{1,3}$'; then
-  printf '{"ip":"%s"}\n' "$ip"
-else
-  printf '{"ip":null}\n'
+state_dir="${XDG_STATE_HOME:-"$HOME/.local/state"}"
+cache_file="$state_dir/public_ip"
+cache_max_age=60
+
+mkdir -p "$state_dir"
+now=$(date +%s)
+
+if [ -f "$cache_file" ]; then
+  mod_time=$(stat -c %Y "$cache_file")
+  age=$((now - mod_time))
+  if [ "$age" -lt "$cache_max_age" ]; then
+    ip=$(cat "$cache_file")
+    if printf '%s' "$ip" | grep -Eq '^([0-9]{1,3}\.){3}[0-9]{1,3}$'; then
+      printf '{"ip":"%s"}\n' "$ip"
+      exit 0
+    fi
+  fi
 fi
+
+ip=$(curl --max-time 2 -fsS https://api.ipify.org 2>/dev/null || true)
+if printf '%s' "$ip" | grep -Eq '^([0-9]{1,3}\.){3}[0-9]{1,3}$'; then
+  printf '%s' "$ip" > "$cache_file"
+  printf '{"ip":"%s"}\n' "$ip"
+  exit 0
+fi
+
+if [ -f "$cache_file" ]; then
+  ip=$(cat "$cache_file")
+  if printf '%s' "$ip" | grep -Eq '^([0-9]{1,3}\.){3}[0-9]{1,3}$'; then
+    printf '{"ip":"%s"}\n' "$ip"
+    exit 0
+  fi
+fi
+printf '{"ip":null}\n'


### PR DESCRIPTION
## Summary
- cache public IP in `$XDG_STATE_HOME/public_ip` for 60 seconds
- shorten curl timeout to 2 seconds and skip cache update on invalid responses

## Testing
- `XDG_STATE_HOME=$tmpdir cyberplasma/scripts/public_ip.sh` (no network, outputs null)
- `tmpdir=$(mktemp -d); printf '1.2.3.4' > $tmpdir/public_ip; XDG_STATE_HOME=$tmpdir cyberplasma/scripts/public_ip.sh`
- `tmpdir=$(mktemp -d); printf '1.2.3.4' > $tmpdir/public_ip; touch -d '2 minutes ago' $tmpdir/public_ip; XDG_STATE_HOME=$tmpdir cyberplasma/scripts/public_ip.sh`
- `shellcheck cyberplasma/scripts/public_ip.sh` *(fails: command not found; `apt-get update` 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a420e73ef88325a6f3600a7d3c80b1