### PR TITLE
docs: expand prerequisites and optional packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,19 @@ Cyberpunk-themed Plasma KDE rice kit. Main color theme right now is purple/cyan/
 ## Prerequisites
 - KDE Plasma 6 with KWin (X11 session required)
 - Git for cloning the repository
+- playerctl for media control
+- jq for JSON processing
+- curl for data retrieval
+- lm-sensors for temperature monitoring
 - (Optional) [EWW](https://elkowar.github.io/eww/) for widget customization
 
 ## Security
 All helper scripts in `cyberplasma/scripts` are POSIX-compliant and run without elevated privileges. Inputs are sanitized, and network requests include fixed timeouts. The project operates entirely in user space without requiring escalated permissions. Continuous integration runs ShellCheck to maintain script quality.
 
 ## Installation
+Optional packages:
+- [GLava](https://github.com/jarcode-foss/glava) for an OpenGL audio visualizer
+- [EWW](https://elkowar.github.io/eww/) for widget customization
 
 ### Window Decorations
 1. Create the Aurorae theme directory:


### PR DESCRIPTION
## Summary
- document playerctl, jq, curl, and lm-sensors as prerequisites
- note optional packages like GLava and EWW in the installation section

## Testing
- `shellcheck install_dependencies.sh` *(fails: command not found; repository errors prevented installing shellcheck)*
- `bash -n install_dependencies.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a544079f208325bc424a0b7c2c8de8