### PR TITLE
Source theme variables before starting Eww

### DIFF
--- a/cyberplasma/scripts/launch-eww.sh
+++ b/cyberplasma/scripts/launch-eww.sh
@@ -3,6 +3,12 @@
 # Determines monitor geometry via xrandr.
 set -euo pipefail
 
+# Load theme variables so Eww can resolve color references
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+set -a
+source "${SCRIPT_DIR}/../theme.env"
+set +a
+
 # Start the daemon if not already running
 if ! eww ping >/dev/null 2>&1; then
   eww daemon


### PR DESCRIPTION
## Summary
- ensure launch-eww.sh exports theme variables before starting the Eww daemon

## Testing
- `eww -c eww log` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5440ba2648325aa5fd8cefc4954fa