### PR TITLE
feat: support sensor filter for temp script

### DIFF
--- a/cyberplasma/eww/widgets/top_bar.yuck
+++ b/cyberplasma/eww/widgets/top_bar.yuck
@@ -5,7 +5,7 @@
 ;; System gauges
 (defpoll cpu :interval "1s" :command "../scripts/cpu.sh" :json true)
 (defpoll ram :interval "5s" :command "../scripts/ram.sh" :json true)
-(defpoll temp :interval "5s" :command "../scripts/temp.sh | jq '{temp: (.[keys[0]])}'" :json true)
+(defpoll temp :interval "5s" :command "../scripts/temp.sh cpu_thermal_zone" :json true)
 
 ;; Network rates and IP information
 (defpoll net :interval "2s" :command "../scripts/net.sh $(../scripts/default_iface.sh)" :json true)

--- a/cyberplasma/scripts/temp.sh
+++ b/cyberplasma/scripts/temp.sh
@@ -3,6 +3,30 @@
 # Avoids elevated privileges and ensures sanitized output.
 set -eu
 
+sensor=$(printf '%s' "${1:-}" | tr -cd 'A-Za-z0-9_-')
+
+if [ -n "$sensor" ]; then
+  found=0
+  for zone in /sys/class/thermal/thermal_zone*/temp; do
+    [ -r "$zone" ] || continue
+    zone_dir=${zone%/temp}
+    name=$(tr -cd 'A-Za-z0-9_-' < "$zone_dir/type")
+    [ "$name" = "$sensor" ] || continue
+    temp_raw=$(cat "$zone")
+    case "$temp_raw" in
+      *[!0-9]*|'') continue ;;
+    esac
+    temp_c=$(awk -v t="$temp_raw" 'BEGIN { printf "%.1f", t/1000 }')
+    printf '{"temp":%s}\n' "$temp_c"
+    found=1
+    break
+  done
+  if [ "$found" -eq 0 ]; then
+    printf '{"temp":0}\n'
+  fi
+  exit 0
+fi
+
 printf '{'
 first=1
 for zone in /sys/class/thermal/thermal_zone*/temp; do


### PR DESCRIPTION
## Summary
- allow optional thermal sensor name in temp.sh and return temp directly
- use sensor-specific temp in top bar without jq

## Testing
- `cyberplasma/scripts/temp.sh`
- `cyberplasma/scripts/temp.sh cpu_thermal_zone`
- `shellcheck cyberplasma/scripts/temp.sh` *(fails: command not found)*
- `apt-get update` *(fails: 403 due to unsigned repository)*

------
https://chatgpt.com/codex/tasks/task_e_68a5440c26548325a2e122515025e9c6