### PR TITLE
Integrate skinned SVG panels with widgets

### DIFF
--- a/cyberplasma/eww/config.yuck
+++ b/cyberplasma/eww/config.yuck
@@ -13,14 +13,14 @@
   :focusable false
   :wm-ignore true
   :stacking "overlay"
-  :geometry (geometry :anchor "top left" :x "0px" :y "0px" :width "100%" :height "30px")
+  :geometry (geometry :anchor "top left" :x "0px" :y "0px" :width "1920px" :height "56px")
   (top_bar))
 
 (defwindow left_column
   :focusable false
   :wm-ignore true
   :stacking "overlay"
-  :geometry (geometry :anchor "left center" :x "0px" :y "0px" :width "220px" :height "100%")
+  :geometry (geometry :anchor "top left" :x "0px" :y "0px" :width "420px" :height "220px")
   (left_column))
 
 (defwindow mpris_controls

--- a/cyberplasma/eww/widgets/left_column.yuck
+++ b/cyberplasma/eww/widgets/left_column.yuck
@@ -1,27 +1,29 @@
-;; Left column widget with system gauges, network metrics, and top processes
+;; Vitals panel widget using skinned SVG
 
-;; System gauges
-(defpoll cpu :interval "1s" :command "../scripts/cpu.sh" :json true)
-(defpoll ram :interval "5s" :command "../scripts/ram.sh" :json true)
+;; Temperature (first available sensor)
 (defpoll temp :interval "5s" :command "../scripts/temp.sh | jq '{temp: (.[keys[0]])}'" :json true)
-
-;; Network rates using dynamically detected interface
-(defpoll net :interval "2s" :command "../scripts/net.sh $(../scripts/default_iface.sh)" :json true)
-
-;; Top processes
-(defpoll top_procs :interval "10s" :command "../scripts/top_procs.sh" :json true)
+;; Uptime
+(defpoll uptime :interval "60s" :command "sh -c 'uptime -p | sed \"s/^up //\"'")
+;; Load averages
+(defpoll load :interval "10s" :command "awk '{print $1 \" \" $2 \" \" $3}' /proc/loadavg")
+;; Power source and battery percentage
+(defpoll power :interval "30s" :command "sh -c 'if [ -r /sys/class/power_supply/AC/online ] && [ $(cat /sys/class/power_supply/AC/online) -eq 1 ]; then echo AC; elif [ -r /sys/class/power_supply/BAT0/capacity ]; then printf \"DC %s%%\" $(cat /sys/class/power_supply/BAT0/capacity); else echo AC; fi'")
 
 (defwidget left_column []
-  (box :class "left-column" :orientation "v" :spacing 8 :vexpand true
-       ;; Gauges
-       (progress :class "cpu" :value cpu.usage :max 100)
-       (progress :class "ram" :value ram.percent :max 100)
-       (progress :class "temp" :value temp.temp :max 100)
-       ;; Network metrics
-       (box :class "net" :spacing 4
-            (label :class "net-rx" :text "Rx ${net.rx_kBps} kB/s")
-            (label :class "net-tx" :text "Tx ${net.tx_kBps} kB/s"))
-       ;; Top processes by CPU
-       (box :class "procs" :orientation "v"
-            (for proc top_procs
-                 (label :class "proc" :text "${proc.cmd} ${proc.cpu}%")))))
+  (overlay :class "vitals-panel" :width 420 :height 220
+           (image :path "../../../chrome/vitals_panel_skinned.svg")
+           ;; Icon seats
+           (image :path "../../../icons/icon_temp.svg" :x "78" :y "36" :width "24" :height "24")
+           (image :path "../../../icons/icon_command_mode.svg" :x "78" :y "68" :width "24" :height "24")
+           (image :path "../../../icons/icon_cpu.svg" :x "78" :y "100" :width "24" :height "24")
+           (image :path "../../../icons/icon_battery.svg" :x "78" :y "132" :width "24" :height "24")
+           ;; Value slots
+           (box :x "110" :y "40" :width "290" :height "20" :halign "start" :valign "center"
+                (label :class "temps" :text "CPU ${temp.temp}°C"))
+           (box :x "110" :y "72" :width "290" :height "20" :halign "start" :valign "center"
+                (label :class "uptime" :text "${uptime}"))
+           (box :x "110" :y "104" :width "290" :height "20" :halign "start" :valign "center"
+                (label :class "load" :text "${load}"))
+           (box :x "110" :y "136" :width "290" :height "20" :halign "start" :valign "center"
+                (label :class "power" :text "${power}"))))
+

--- a/cyberplasma/eww/widgets/mpris_controls.yuck
+++ b/cyberplasma/eww/widgets/mpris_controls.yuck
@@ -1,6 +1,12 @@
-;; Media player controls using playerctl
-(defwidget mpris_controls []
-  (box :class "mpris-controls" :space-evenly true
-       (button :class "mpris-prev" :onclick "playerctl previous" "⏮")
-       (button :class "mpris-play" :onclick "playerctl play-pause" "⏯")
-       (button :class "mpris-next" :onclick "playerctl next" "⏭")))
+;; Media player controls using playerctl with SVG icons
+(defwidget mpris_controls [status]
+  (box :class "mpris-controls" :spacing 8
+       (button :class "mpris-prev" :onclick "playerctl previous"
+               (image :path "../../../icons/mediabutton_previous.svg" :width 24 :height 24))
+       (button :class "mpris-play" :onclick "playerctl play-pause"
+               (image :path (if (= status "playing")
+                                "../../../icons/mediabutton_pause.svg"
+                                "../../../icons/mediabutton_play.svg")
+                      :width 24 :height 24))
+       (button :class "mpris-next" :onclick "playerctl next"
+               (image :path "../../../icons/mediabutton_next.svg" :width 24 :height 24))))

--- a/cyberplasma/eww/widgets/top_bar.yuck
+++ b/cyberplasma/eww/widgets/top_bar.yuck
@@ -1,4 +1,4 @@
-;; Top bar widget with time, system metrics, network, IP info, and media controls
+;; Top bar widget integrated with control strip SVG
 ;; Time and date
 (defpoll datetime :interval "1s" :command "date +'%Y-%m-%d %H:%M:%S'")
 
@@ -7,7 +7,7 @@
 (defpoll ram :interval "5s" :command "../scripts/ram.sh" :json true)
 (defpoll temp :interval "5s" :command "../scripts/temp.sh | jq '{temp: (.[keys[0]])}'" :json true)
 
-;; Network rates and IP information
+;; Network and IP information
 (defpoll net :interval "2s" :command "../scripts/net.sh $(../scripts/default_iface.sh)" :json true)
 (defpoll vpn :interval "10s" :command "../scripts/vpn.sh" :json true)
 (defpoll local_ip :interval "60s" :command "../scripts/local_ip.sh" :json true)
@@ -17,21 +17,26 @@
 (defpoll mpris :interval "2s" :command "../scripts/mpris.sh" :json true)
 
 (defwidget top_bar []
-  (box :class "top-bar" :space-evenly true :hexpand true
-       ;; Time/Date
-       (label :class "datetime" :text "${datetime}")
-       ;; Gauges
-       (progress :class "cpu" :value cpu.usage :max 100)
-       (progress :class "ram" :value ram.percent :max 100)
-       (progress :class "temp" :value temp.temp :max 100)
-       ;; Network rates
-       (label :class "net-rx" :text "Rx ${net.rx_kBps} kB/s")
-       (label :class "net-tx" :text "Tx ${net.tx_kBps} kB/s")
-       ;; IP information
-       (label :class "vpn" :text "VPN ${vpn.vpn}")
-       (label :class "local-ip" :text "${local_ip[net.interface]}")
-       (label :class "public-ip" :text "${public_ip.ip}")
-       ;; Now playing with controls
-       (box :class "mpris" :spacing 4
-            (label :class "mpris-text" :text "${mpris.artist} - ${mpris.title}")
-            (mpris_controls))))
+  (overlay :class "top-bar" :width 1920 :height 56
+           (image :path "../../../chrome/control_strip_skinned.svg")
+           ;; Network slot
+           (box :class "slot-net" :x "250" :y "12" :width "150" :height "32" :halign "start" :valign "center" :spacing 4
+                (label :class "iface" :text "${net.interface}")
+                (label :class "local-ip" :text "${local_ip[net.interface]}")
+                (label :class "public-ip" :text "${public_ip.ip}")
+                (image :class "vpn-icon" :width 16 :height 16
+                       :path (if vpn.vpn "../../../icons/icon_vpn_on.svg" "../../../icons/icon_vpn_off.svg")))
+           ;; Media controls slot
+           (box :class "slot-media" :x "650" :y "12" :width "500" :height "32" :halign "start" :valign "center" :spacing 4
+                (mpris_controls :status mpris.status)
+                (label :class "mpris-text" :text "${mpris.artist} - ${mpris.title}"))
+           ;; System mini metrics slot
+           (box :class "slot-sysmini" :x "1190" :y "12" :width "360" :height "32" :halign "start" :valign "center" :spacing 8
+                (image :path "../../../icons/icon_cpu.svg" :width 16 :height 16)
+                (label :class "cpu" :text "${cpu.usage}%")
+                (image :path "../../../icons/icon_temp.svg" :width 16 :height 16)
+                (label :class "temp" :text "${temp.temp}°C")
+                (label :class "ram" :text "${ram.percent}%"))
+           ;; Time slot
+           (box :class "slot-time" :x "1590" :y "12" :width "280" :height "32" :halign "center" :valign "center"
+                (label :class "datetime" :text "${datetime}"))))


### PR DESCRIPTION
## Summary
- Embed control strip SVG in top bar and wire up network, system metrics, media controls, and clock into slot IDs
- Add vitals panel SVG with temp, uptime, load, and power metrics plus icon seats
- Replace text-based media buttons with SVG icons and adjust window geometry

## Testing
- `eww --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a544ee4bf08325862a0f0ae3c87e9e