### PR TITLE
Add per-core CPU bar matrix and RAM dot usage grid

### DIFF
--- a/cyberplasma/eww/widgets/left_column.yuck
+++ b/cyberplasma/eww/widgets/left_column.yuck
@@ -1,6 +1,7 @@
 ;; Left column widget with system gauges, network metrics, and top processes
 
 ;; System gauges
+(defpoll cores :interval "3600s" :command "nproc --all")
 (defpoll cpu :interval "1s" :command "../scripts/cpu.sh" :json true)
 (defpoll ram :interval "5s" :command "../scripts/ram.sh" :json true)
 (defpoll temp :interval "5s" :command "../scripts/temp.sh | jq '{temp: (.[keys[0]])}'" :json true)
@@ -13,9 +14,29 @@
 
 (defwidget left_column []
   (box :class "left-column" :orientation "v" :spacing 8 :vexpand true
-       ;; Gauges
-       (progress :class "cpu" :value cpu.usage :max 100)
-       (progress :class "ram" :value ram.percent :max 100)
+      ;; Gauges
+       (box :id "bar-matrix" :orientation "h" :spacing 2
+            (for i (range 0 cores)
+                 (progress :orientation "v" :vexpand true :max 100
+                           :value (nth cpu.cores i)
+                           :class (format "cpu-bar %s"
+                                          (if (> (nth cpu.cores i) 95)
+                                              "cp-err"
+                                              (if (> (nth cpu.cores i) 80)
+                                                  "cp-warn"
+                                                  "cp-accent"))))))
+       (box :id "ram-matrix" :orientation "v" :spacing 1
+            (for r (range 0 10)
+                 (box :orientation "h" :spacing 1
+                      (for c (range 0 24)
+                           (box :width 10 :height 10
+                                :class (if (< (+ (* r 24) c) ram.used_dots)
+                                             (if (>= (+ (* r 24) c) 216)
+                                                 "ram-dot cp-err"
+                                                 (if (>= (+ (* r 24) c) 192)
+                                                     "ram-dot cp-warn"
+                                                     "ram-dot cp-accent"))
+                                             "ram-dot")))))
        (progress :class "temp" :value temp.temp :max 100)
        ;; Network metrics
        (box :class "net" :spacing 4

--- a/cyberplasma/scripts/cpu.sh
+++ b/cyberplasma/scripts/cpu.sh
@@ -1,28 +1,51 @@
 #!/bin/sh
-# Output CPU usage percentage as JSON.
+# Output per-core and average CPU usage as JSON.
 # Avoids elevated privileges and ensures sanitized output.
 set -eu
 
-read -r _ user nice system idle iowait irq softirq steal guest < /proc/stat
-prev_total=$((user + nice + system + idle + iowait + irq + softirq + steal))
-prev_idle=$((idle + iowait))
+cores=$(nproc --all)
 
+# capture initial per-core statistics
+prev=$(grep '^cpu[0-9]' /proc/stat)
 sleep 1
+curr=$(grep '^cpu[0-9]' /proc/stat)
 
-read -r _ user nice system idle iowait irq softirq steal guest < /proc/stat
-total=$((user + nice + system + idle + iowait + irq + softirq + steal))
-idle_all=$((idle + iowait))
+# adjust core count to available lines
+lines=$(printf '%s\n' "$prev" | wc -l)
+if [ "$lines" -lt "$cores" ]; then
+  cores=$lines
+fi
 
-delta_total=$((total - prev_total))
-delta_idle=$((idle_all - prev_idle))
+cores_json=""
+sum=0
 
-usage=$(awk -v total="$delta_total" -v idle="$delta_idle" '
-BEGIN {
-  if (total > 0) {
-    printf "%.2f", (1 - idle / total) * 100
-  } else {
-    print "0.00"
-  }
-}')
+for i in $(seq 0 $((cores - 1))); do
+  prev_line=$(printf '%s\n' "$prev" | sed -n "$((i + 1))p")
+  curr_line=$(printf '%s\n' "$curr" | sed -n "$((i + 1))p")
 
-printf '{"usage":%s}\n' "$usage"
+  # shell splits fields for us
+  set -- $prev_line
+  prev_total=$(( $2 + $3 + $4 + $5 + $6 + $7 + $8 + $9 ))
+  prev_idle=$(( $5 + $6 ))
+
+  set -- $curr_line
+  total=$(( $2 + $3 + $4 + $5 + $6 + $7 + $8 + $9 ))
+  idle_all=$(( $5 + $6 ))
+
+  delta_total=$(( total - prev_total ))
+  delta_idle=$(( idle_all - prev_idle ))
+
+  if [ "$delta_total" -gt 0 ]; then
+    usage=$(awk -v t="$delta_total" -v i="$delta_idle" 'BEGIN{printf "%.2f", (1 - i/t) * 100}')
+  else
+    usage="0.00"
+  fi
+
+  cores_json="$cores_json$usage,"
+  sum=$(awk -v s="$sum" -v u="$usage" 'BEGIN{printf "%.2f", s+u}')
+done
+
+cores_json=${cores_json%,}
+avg=$(awk -v s="$sum" -v c="$cores" 'BEGIN{if (c>0) printf "%.2f", s/c; else print "0.00"}')
+
+printf '{"usage":%s,"cores":[%s]}\n' "$avg" "$cores_json"

--- a/cyberplasma/scripts/ram.sh
+++ b/cyberplasma/scripts/ram.sh
@@ -9,5 +9,7 @@ available=$(awk '/^MemAvailable:/ {print $2}' "$meminfo")
 used=$((total - available))
 
 percent=$(awk -v u="$used" -v t="$total" 'BEGIN { if (t > 0) printf "%.2f", (u / t) * 100; else print "0.00" }')
+dots_total=240
+used_dots=$(awk -v u="$used" -v t="$total" -v d="$dots_total" 'BEGIN { if (t > 0) printf "%d", (u / t) * d; else print "0" }')
 
-printf '{"total_kb":%s,"used_kb":%s,"percent":%s}\n' "$total" "$used" "$percent"
+printf '{"total_kb":%s,"used_kb":%s,"percent":%s,"used_dots":%s}\n' "$total" "$used" "$percent" "$used_dots"


### PR DESCRIPTION
## Summary
- Render per-core CPU usage bars based on `nproc --all` inside the CPU panel's `#bar-matrix`.
- Replace RAM gauge with a 24×10 dot matrix that highlights high usage with warn and err colors.

## Testing
- `bash -n cyberplasma/scripts/cpu.sh`
- `cyberplasma/scripts/cpu.sh | head -n 5`
- `bash -n cyberplasma/scripts/ram.sh`
- `cyberplasma/scripts/ram.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a544f185648325ab0330b1384959ff