### PR TITLE
Add control strip widget and mode-aware launcher

### DIFF
--- a/cyberplasma/eww/config.yuck
+++ b/cyberplasma/eww/config.yuck
@@ -4,6 +4,7 @@
 (include "./widgets/top_bar.yuck")
 (include "./widgets/left_column.yuck")
 (include "./widgets/mpris_controls.yuck")
+(include "./widgets/control_strip.yuck")
 
 ;; Link shared styles
 (include-css "../style.scss")
@@ -29,3 +30,10 @@
   :stacking "overlay"
   :geometry (geometry :anchor "center" :x "0px" :y "0px" :width "300px" :height "60px")
   (mpris_controls))
+
+(defwindow control_strip
+  :focusable false
+  :wm-ignore true
+  :stacking "overlay"
+  :geometry (geometry :anchor "top left" :x "0px" :y "0px" :width "100%" :height "56px")
+  (control_strip))

--- a/cyberplasma/eww/widgets/control_strip.yuck
+++ b/cyberplasma/eww/widgets/control_strip.yuck
@@ -1,0 +1,10 @@
+;; Control strip widget using the skinned SVG
+(defwidget control_strip []
+  (svg :path "../../../chrome/control_strip_skinned.svg"
+       (slot slot-pins (box :class "slot-pins"))
+       (slot slot-net (box :class "slot-net"))
+       (slot slot-viz (box :class "slot-viz"))
+       (slot slot-media (box :class "slot-media"))
+       (slot slot-sysmini (box :class "slot-sysmini"))
+       (slot slot-time (box :class "slot-time"))
+       (slot slot-modebadge (box :class "slot-modebadge"))))

--- a/cyberplasma/scripts/launch-eww.sh
+++ b/cyberplasma/scripts/launch-eww.sh
@@ -2,6 +2,7 @@
 # Launch Eww widgets for each connected monitor using --screen.
 # Determines monitor geometry via xrandr.
 set -euo pipefail
+MODE=${CYBERPLASMA_MODE:-command}
 
 # Start the daemon if not already running
 if ! eww ping >/dev/null 2>&1; then
@@ -23,11 +24,14 @@ xrandr --query | awk '/ connected/{print $1, $3}' | while read -r name geometry;
   # Open widgets on the given monitor. Geometry inside config.yuck
   # is relative to the screen, so the coordinates computed above are
   # primarily informational and available for potential future use.
-  eww open top_bar --screen "$name"
+  if [[ "$MODE" == "control" ]]; then
+    eww open control_strip --screen "$name"
+  else
+    eww open top_bar --screen "$name"
+  fi
   eww open left_column --screen "$name"
 done
 
 # Optionally open standalone mpris controls on the primary monitor
 # only if desired by users of this script. Commented out by default.
 # eww open mpris_controls --screen "$(xrandr --query | awk '/ primary/{print $1}')"
-


### PR DESCRIPTION
## Summary
- Add new `control_strip` widget loading `control_strip_skinned.svg` with slots for pins, networking, visualization, media, system metrics, time, and mode badge.
- Expose `control_strip` window in `config.yuck`.
- Update `launch-eww.sh` to launch `control_strip` only when `CYBERPLASMA_MODE=control`.

## Testing
- `bash -n cyberplasma/scripts/launch-eww.sh`
- `shellcheck cyberplasma/scripts/launch-eww.sh` *(fails: command not found)*
- `eww --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a544f525688325a0eb5d5897673085