### PR TITLE
Use SVG icons for MPRIS controls with dynamic play/pause

### DIFF
--- a/cyberplasma/eww/widgets/mpris_controls.yuck
+++ b/cyberplasma/eww/widgets/mpris_controls.yuck
@@ -1,9 +1,12 @@
-;; Media player controls using playerctl
-(defwidget mpris_controls []
-  (box :class "mpris-controls" :space-evenly true
-       (image :class "mpris-prev" :onclick "playerctl previous"
-              :path "../../../icons/mediabutton_previous.svg")
-       (image :class "mpris-play" :onclick "playerctl play-pause"
-              :path "${mpris.status == \"playing\" ? \"../../../icons/mediabutton_pause.svg\" : \"../../../icons/mediabutton_play.svg\"}")
-       (image :class "mpris-next" :onclick "playerctl next"
-              :path "../../../icons/mediabutton_next.svg")))
+;; Media player controls using playerctl with SVG icons
+(defwidget mpris_controls [status]
+  (box :class "mpris-controls" :spacing 8
+       (button :class "mpris-prev" :onclick "playerctl previous"
+               (image :path "../../../icons/mediabutton_previous.svg" :width 24 :height 24))
+       (button :class "mpris-play" :onclick "playerctl play-pause"
+               (image :path (if (= status "playing")
+                                "../../../icons/mediabutton_pause.svg"
+                                "../../../icons/mediabutton_play.svg")
+                      :width 24 :height 24))
+       (button :class "mpris-next" :onclick "playerctl next"
+               (image :path "../../../icons/mediabutton_next.svg" :width 24 :height 24))))

--- a/cyberplasma/eww/widgets/mpris_controls.yuck
+++ b/cyberplasma/eww/widgets/mpris_controls.yuck
@@ -1,6 +1,9 @@
 ;; Media player controls using playerctl
 (defwidget mpris_controls []
   (box :class "mpris-controls" :space-evenly true
-       (button :class "mpris-prev" :onclick "playerctl previous" "⏮")
-       (button :class "mpris-play" :onclick "playerctl play-pause" "⏯")
-       (button :class "mpris-next" :onclick "playerctl next" "⏭")))
+       (image :class "mpris-prev" :onclick "playerctl previous"
+              :path "../../../icons/mediabutton_previous.svg")
+       (image :class "mpris-play" :onclick "playerctl play-pause"
+              :path "${mpris.status == \"playing\" ? \"../../../icons/mediabutton_pause.svg\" : \"../../../icons/mediabutton_play.svg\"}")
+       (image :class "mpris-next" :onclick "playerctl next"
+              :path "../../../icons/mediabutton_next.svg")))


### PR DESCRIPTION
## Summary
- swap text-based media buttons for SVG image widgets
- show play or pause icon based on current MPRIS status

## Testing
- `eww --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y eww` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a544fc3f1c8325b12e39de47dd7948