### PR TITLE
refactor: unify control strip widget

### DIFF
--- a/cyberplasma/eww/widgets/control_strip.yuck
+++ b/cyberplasma/eww/widgets/control_strip.yuck
@@ -17,10 +17,8 @@
 ;; Media info
 (defpoll mpris :interval "2s" :command "../scripts/mpris.sh" :json true)
 
-(defwidget control_strip [width]
-  (svg :path "../../../chrome/control_strip_skinned.svg" :width width
 (defwidget control_strip []
-  (svg :path (format "%s/chrome/control_strip_skinned.svg" (getenv "CYBERPLASMA_ROOT"))
+  (svg :path "../../../chrome/control_strip_skinned.svg"
        (slot slot-pins (box :class "slot-pins"))
        (slot slot-net (box :class "slot-net" :halign "start" :valign "center" :spacing 4
                                   (label :class "iface" :text "${net.interface}")
@@ -40,9 +38,4 @@
                                    (label :class "ram" :text "${ram.percent}%")))
        (slot slot-time (box :class "slot-time" :halign "center" :valign "center"
                             (label :class "datetime" :text "${datetime}")))
-        (slot slot-net (box :class "slot-net"))
-        (slot slot-viz (box :class "slot-viz"))
-        (slot slot-media (box :class "slot-media"))
-        (slot slot-sysmini (box :class "slot-sysmini"))
-       (slot slot-time (box :class "slot-time"))
        (slot slot-modebadge (box :class "slot-modebadge"))))


### PR DESCRIPTION
## Summary
- simplify control strip widget by removing duplicate definition
- keep single set of polling declarations
- use consistent relative paths for icons and SVG

## Testing
- `eww --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5557241b88325a1b08ad5ade30229