### PR TITLE
Clean up MPRIS controls widget

### DIFF
--- a/cyberplasma/eww/widgets/mpris_controls.yuck
+++ b/cyberplasma/eww/widgets/mpris_controls.yuck
@@ -10,11 +10,3 @@
                       :width 24 :height 24))
        (button :class "mpris-next" :onclick "playerctl next"
                (image :path (format "%s/icons/mediabutton_next.svg" (getenv "CYBERPLASMA_ROOT")) :width 24 :height 24))))
-               (image :class "cp-chrome" :path "../../../icons/mediabutton_previous.svg" :width 24 :height 24))
-       (button :class "mpris-play" :onclick "playerctl play-pause"
-               (image :class "cp-accent" :path (if (= status "playing")
-                                "../../../icons/mediabutton_pause.svg"
-                                "../../../icons/mediabutton_play.svg")
-                      :width 24 :height 24))
-       (button :class "mpris-next" :onclick "playerctl next"
-               (image :class "cp-chrome" :path "../../../icons/mediabutton_next.svg" :width 24 :height 24))))


### PR DESCRIPTION
## Summary
- remove duplicated relative-path implementation from MPRIS controls widget
- rely solely on environment-variable based icon paths and fix unbalanced parenthesis

## Testing
- `npm test` *(fails: ENOENT, could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5557c05ac83259eae15c0b175e11e