### PR TITLE
Clean up duplicate color variables and classes

### DIFF
--- a/cyberplasma/style.scss
+++ b/cyberplasma/style.scss
@@ -8,7 +8,6 @@ $bg: env(BG);
 $fg: env(FG);
 $panel: env(PANEL);
 $accent: env(ACCENT);
-$accent2: env(ACCENT_ALT);
 $border: env(BORDER);
 $chrome: env(CHROME);
 $accent2: env(ACCENT2);
@@ -17,38 +16,6 @@ $muted: env(MUTED);
 $ok: env(OK);
 $warn: env(WARN);
 $err: env(ERR);
-
-.cp-chrome {
-  color: $fg;
-}
-
-.cp-accent {
-  color: $accent;
-}
-
-.cp-accent2 {
-  color: $accent2;
-}
-
-.cp-text {
-  color: $fg;
-}
-
-.cp-muted {
-  color: $muted;
-}
-
-.cp-ok {
-  color: $ok;
-}
-
-.cp-warn {
-  color: $warn;
-}
-
-.cp-err {
-  color: $err;
-}
 
 
 // Top overlay strip skinned via SVG


### PR DESCRIPTION
## Summary
- Use a single `$accent2` defined from `ACCENT2`
- Drop redundant `.cp-*` color class block for consistent definitions

## Testing
- `npx sass cyberplasma/style.scss >/tmp/style.css` *(fails: 403 Forbidden fetching sass)*

------
https://chatgpt.com/codex/tasks/task_e_68a55806916483258b56476dfed3d8fe