### PR TITLE
Use home-based path for EWW post-start script

### DIFF
--- a/cyberplasma/systemd/user/eww.service
+++ b/cyberplasma/systemd/user/eww.service
@@ -8,7 +8,7 @@ After=graphical-session.target
 
 [Service]
 ExecStart=eww daemon
-ExecStartPost=../../../cyberplasma/scripts/launch-eww.sh
+ExecStartPost=%h/cyberplasma/scripts/launch-eww.sh
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
## Summary
- reference launch-eww script with an absolute home-based path in eww.service

## Testing
- `systemd-analyze verify cyberplasma/systemd/user/eww.service` *(fails: Command eww is not executable)*

------
https://chatgpt.com/codex/tasks/task_e_68a5580782a08325b05328357847e8f9