### PR TITLE
Fix duplicate control strip launch

### DIFF
--- a/cyberplasma/scripts/launch-eww.sh
+++ b/cyberplasma/scripts/launch-eww.sh
@@ -37,7 +37,6 @@ xrandr --query | awk '/ connected/{for(i=1;i<=NF;i++) if ($i ~ /[0-9]+x[0-9]+\+/
   # is relative to the screen, so the coordinates computed above are
   # primarily informational and available for potential future use.
   if [[ "$MODE" == "control" ]]; then
-    eww open control_strip --screen "$name"
     eww open control_strip --screen "$name" --arg monitor_width="$width"
   else
     eww open top_bar --screen "$name" --arg monitor_width="$width"


### PR DESCRIPTION
## Summary
- Remove duplicate `control_strip` launch and pass monitor width in single call

## Testing
- `bash -n cyberplasma/scripts/launch-eww.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a55815183c8325b9b029610de241d1