### PR TITLE
Validate numeric screen argument for panel visibility script

### DIFF
--- a/scripts/panel_visibility.sh
+++ b/scripts/panel_visibility.sh
@@ -17,11 +17,18 @@ if [[ "$action" != "show" && "$action" != "hide" ]]; then
     exit 1
 fi
 
+if [[ ! $screen =~ ^[0-9]+$ ]]; then
+    echo "Screen must be a numeric value" >&2
+    exit 1
+fi
+
+screen_sanitized="${BASH_REMATCH[0]}"
+
 script="
 const ids = panelIds;
 for (var i = 0; i < ids.length; ++i) {
   var p = panelById(ids[i]);
-  if (p.screen === $screen) {
+  if (p.screen === $screen_sanitized) {
     if ('$action' === 'hide') {
       p.hiding = 'autohide';
       p.hide();


### PR DESCRIPTION
## Summary
- ensure `panel_visibility.sh` validates numeric `screen` argument
- use sanitized screen id when building `qdbus` script

## Testing
- `bash -n scripts/panel_visibility.sh`
- `bash scripts/panel_visibility.sh show abc`
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a569c49cd88325a2bbd940316fcb22