### PR TITLE
Prefer primary screen when parsing xrandr output

### DIFF
--- a/scripts/cp_layouts.py
+++ b/scripts/cp_layouts.py
@@ -59,10 +59,15 @@ def current_screen() -> str:
     except Exception:
         return "unknown"
 
+    first_connected: str | None = None
     for line in output.splitlines():
         if " connected" in line:
-            return line.split()[0]
-    return "unknown"
+            screen = line.split()[0]
+            if " primary" in line:
+                return screen
+            if first_connected is None:
+                first_connected = screen
+    return first_connected or "unknown"
 
 
 def current_mode() -> str:


### PR DESCRIPTION
## Summary
- Prefer the primary output when detecting current screen
- Fall back to the first connected output when none marked primary

## Testing
- `python -m pytest`
- `python -m py_compile scripts/cp_layouts.py`


------
https://chatgpt.com/codex/tasks/task_e_68a569cde2a88325a2d636cc12500ee7