### PR TITLE
Add test suites and CI for scripts

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,21 +1,32 @@
-name: Shellcheck
+name: CI
 
 on:
   push:
     paths:
+      - 'scripts/cp_layouts.py'
       - 'cyberplasma/scripts/*.sh'
+      - 'tests/**'
       - '.github/workflows/shellcheck.yml'
   pull_request:
     paths:
+      - 'scripts/cp_layouts.py'
       - 'cyberplasma/scripts/*.sh'
+      - 'tests/**'
       - '.github/workflows/shellcheck.yml'
 
 jobs:
-  shellcheck:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install shellcheck
-        run: sudo apt-get update && sudo apt-get install -y shellcheck
-      - name: Run shellcheck
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck bats python3-pip
+          python3 -m pip install pytest
+      - name: Run ShellCheck
         run: shellcheck cyberplasma/scripts/*.sh
+      - name: Run pytest
+        run: python3 -m pytest
+      - name: Run Bats tests
+        run: bats tests/shell

--- a/tests/shell/default_iface.bats
+++ b/tests/shell/default_iface.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+
+setup() {
+  stub_dir="${BATS_TEST_TMPDIR}/bin"
+  mkdir -p "$stub_dir"
+  PATH="$stub_dir:$PATH"
+  cat <<'EOF' >"$stub_dir/ip"
+#!/bin/sh
+echo "1.0.0.0 dev eth0 src 192.168.1.10"
+EOF
+  chmod +x "$stub_dir/ip"
+}
+
+@test "default_iface prints interface name" {
+  run "${BATS_TEST_DIRNAME}/../../cyberplasma/scripts/default_iface.sh"
+  [ "$status" -eq 0 ]
+  [ "$output" = "eth0" ]
+}

--- a/tests/shell/local_ip.bats
+++ b/tests/shell/local_ip.bats
@@ -1,0 +1,21 @@
+#!/usr/bin/env bats
+
+setup() {
+  stub_dir="${BATS_TEST_TMPDIR}/bin"
+  mkdir -p "$stub_dir"
+  PATH="$stub_dir:$PATH"
+  cat <<'EOF' >"$stub_dir/ip"
+#!/bin/sh
+cat <<'OUT'
+1: eth0    inet 192.168.1.10/24 brd 192.168.1.255 scope global eth0
+2: wlan0   inet 10.0.0.5/24 brd 10.0.0.255 scope global wlan0
+OUT
+EOF
+  chmod +x "$stub_dir/ip"
+}
+
+@test "local_ip outputs JSON mapping interfaces to IPs" {
+  run "${BATS_TEST_DIRNAME}/../../cyberplasma/scripts/local_ip.sh"
+  [ "$status" -eq 0 ]
+  [ "$output" = '{"eth0":"192.168.1.10","wlan0":"10.0.0.5"}' ]
+}

--- a/tests/test_cp_layouts.py
+++ b/tests/test_cp_layouts.py
@@ -1,0 +1,45 @@
+import json
+import sys
+from pathlib import Path
+
+# Ensure scripts directory is on the path for importing cp_layouts
+scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(scripts_dir))
+
+import cp_layouts  # type: ignore
+
+
+def _setup_state(monkeypatch, tmp_path):
+    monkeypatch.setattr(cp_layouts, "STATE_DIR", str(tmp_path))
+    monkeypatch.setattr(cp_layouts, "LAYOUT_FILE", str(tmp_path / "cp_layouts.json"))
+    monkeypatch.setattr(cp_layouts, "MODE_FILE", str(tmp_path / "bismuth_mode"))
+    monkeypatch.setattr(cp_layouts, "current_key", lambda: "screen_mode")
+
+
+def _read_data(tmp_path):
+    with open(tmp_path / "cp_layouts.json") as f:
+        return json.load(f)
+
+
+def test_cycle_changes_current(monkeypatch, tmp_path):
+    _setup_state(monkeypatch, tmp_path)
+    data = {"screen_mode": {"current": 0, "presets": [{}, {}]}}
+    (tmp_path / "cp_layouts.json").write_text(json.dumps(data))
+
+    cp_layouts.cycle("next")
+    assert _read_data(tmp_path)["screen_mode"]["current"] == 1
+
+    cp_layouts.cycle("prev")
+    assert _read_data(tmp_path)["screen_mode"]["current"] == 0
+
+
+def test_move_offsets_widgets(monkeypatch, tmp_path):
+    _setup_state(monkeypatch, tmp_path)
+    data = {"screen_mode": {"current": 0, "presets": [{"widget": {"x": 0, "y": 0}}]}}
+    (tmp_path / "cp_layouts.json").write_text(json.dumps(data))
+
+    cp_layouts.move("right")
+    cp_layouts.move("down")
+
+    preset = _read_data(tmp_path)["screen_mode"]["presets"][0]["widget"]
+    assert preset == {"x": cp_layouts.STEP, "y": cp_layouts.STEP}


### PR DESCRIPTION
## Summary
- add pytest tests for `cp_layouts.py`
- add Bats tests for network shell scripts
- run shellcheck, pytest and bats in CI

## Testing
- `python -m pytest tests/test_cp_layouts.py -q`
- `shellcheck cyberplasma/scripts/*.sh` *(fails: command not found)*
- `bats tests/shell` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a569d0c03483259e6de20ece4280e9