### PR TITLE
Validate panel screen id before toggling panel

### DIFF
--- a/scripts/toggle_tiling.sh
+++ b/scripts/toggle_tiling.sh
@@ -37,9 +37,13 @@ echo "$MODE" > "$STATE_FILE"
 # ("free") shows it again.
 panel_screen="${CYBERPLASMA_PANEL_SCREEN_ID:-}"
 if [[ -n "$panel_screen" ]]; then
-    if [[ "$MODE" == "grid" ]]; then
-        "$HOME"/scripts/panel_visibility.sh hide "$panel_screen"
+    if [[ "$panel_screen" =~ ^[0-9]+$ ]]; then
+        if [[ "$MODE" == "grid" ]]; then
+            "$HOME"/scripts/panel_visibility.sh hide "$panel_screen"
+        else
+            "$HOME"/scripts/panel_visibility.sh show "$panel_screen"
+        fi
     else
-        "$HOME"/scripts/panel_visibility.sh show "$panel_screen"
+        echo "Warning: invalid CYBERPLASMA_PANEL_SCREEN_ID '$panel_screen'; skipping panel toggling" >&2
     fi
 fi


### PR DESCRIPTION
## Summary
- ensure toggle_tiling validates `CYBERPLASMA_PANEL_SCREEN_ID` matches digits before using
- warn and skip panel visibility if an invalid id is provided

## Testing
- `pytest -q`
- ⚠️ `bats tests/shell` *(missing: command not found; apt repositories 403 when attempting installation)*

------
https://chatgpt.com/codex/tasks/task_e_68a56d2b68c883258b28d82edee4866b