### PR TITLE
Add Python requirements file and installer script

### DIFF
--- a/install_python_dependencies.sh
+++ b/install_python_dependencies.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Install Python packages defined in requirements.txt.
+
+set -euo pipefail
+
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON=python3
+elif command -v python >/dev/null 2>&1; then
+  PYTHON=python
+else
+  echo "Error: Python is required but was not found." >&2
+  exit 1
+fi
+
+if ! $PYTHON -m pip --version >/dev/null 2>&1; then
+  echo "Error: pip is not installed for $PYTHON." >&2
+  exit 1
+fi
+
+$PYTHON -m pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Python dependencies for CyberPlasma
+pytest>=7.0


### PR DESCRIPTION
## Summary
- Add `requirements.txt` for project Python dependencies
- Introduce `install_python_dependencies.sh` to install dependencies via pip

## Testing
- `python3 -m pytest`
- `shellcheck install_python_dependencies.sh` *(fails: command not found, repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a5675bcfc08325a68b4c1e06e5883b