### PR TITLE
Validate screen and mode arguments

### DIFF
--- a/scripts/mode_engine.sh
+++ b/scripts/mode_engine.sh
@@ -84,6 +84,16 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+if [[ -n "$screen" ]] && [[ ! "$screen" =~ ^[A-Za-z0-9_-]+$ ]]; then
+    echo "Error: invalid screen '$screen'; must match [A-Za-z0-9_-]+" >&2
+    exit 1
+fi
+
+if [[ -n "$mode" ]] && [[ ! "$mode" =~ ^[A-Za-z0-9_-]+$ ]]; then
+    echo "Error: invalid mode '$mode'; must match [A-Za-z0-9_-]+" >&2
+    exit 1
+fi
+
 if [[ "$do_toggle_all" == true ]]; then
     toggle_all
 elif [[ -n "$screen" ]]; then


### PR DESCRIPTION
## Summary
- validate `--screen` and `--mode` inputs using `[A-Za-z0-9_-]+`

## Testing
- `pytest`
- `bats tests/shell` *(fails: command not found)*
- `shellcheck scripts/mode_engine.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a574f9d2a48325acf431a934a32eb3