### PR TITLE
Validate Bismuth mode during login

### DIFF
--- a/scripts/apply_bismuth_mode.sh
+++ b/scripts/apply_bismuth_mode.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Apply previously saved Bismuth mode on login.
+# Accepted mode values: grid or free. Defaults to free if invalid.
 
 set -euo pipefail
 
@@ -8,5 +9,8 @@ STATE_FILE="$STATE_DIR/bismuth_mode"
 
 if [[ -f "$STATE_FILE" ]]; then
     mode=$(<"$STATE_FILE")
+    if [[ "$mode" != "grid" && "$mode" != "free" ]]; then
+        mode="free"
+    fi
     "$HOME"/scripts/toggle_tiling.sh --"$mode"
 fi


### PR DESCRIPTION
## Summary
- Document allowed Bismuth modes
- Default to `free` when saved mode is invalid

## Testing
- `shellcheck scripts/apply_bismuth_mode.sh`
- `pytest -q`
- `bats tests/shell` *(fails: command not found)*
- `apt-get update` *(fails: repository is no longer signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a574faad5883258c95477458ad1dfe