### PR TITLE
Resolve helper script lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ A basic EWW configuration is included under `cyberplasma/eww`:
    ```
 
 ### Screen Modes
+Install the helper scripts to a directory on your `PATH` (for example,
+`~/.local/bin`). Each script looks for its companions relative to its own
+location, so keeping them together ensures they can find their helpers.
+
 Restore saved display configurations at login by enabling the user service:
 
 ```bash

--- a/cyberplasma/systemd/user/README.md
+++ b/cyberplasma/systemd/user/README.md
@@ -16,7 +16,9 @@ These units manage optional components for the CyberPlasma setup. The list below
 - `yakuake` for `yakuake.service`
 - `bismuth` for `bismuth-mode.service`
 
-Ensure these packages are installed before enabling the services.
+Ensure these packages are installed before enabling the services. The helper
+scripts referenced by the units must also reside in a directory listed in
+your `PATH` (for example, `~/.local/bin`).
 
 ## Widgets
 The `eww.service` expects widgets named `top_bar` and `left_column` to be defined in your EWW configuration.
@@ -48,5 +50,6 @@ Export `CYBERPLASMA_PANEL_SCREEN_ID` with the desired screen number so
 export CYBERPLASMA_PANEL_SCREEN_ID=1
 ```
 
-Copy the `panel_visibility.sh` script to `~/scripts/` if it is not
-already present.
+Install `toggle_tiling.sh` and `panel_visibility.sh` together in a directory on
+your `PATH`. The scripts locate their helpers relative to their own location, so
+keeping them in the same directory ensures the panel toggling feature works.

--- a/cyberplasma/systemd/user/bismuth-mode.service
+++ b/cyberplasma/systemd/user/bismuth-mode.service
@@ -6,7 +6,7 @@ Description=Restore Bismuth tiling mode
 After=graphical-session.target
 
 [Service]
-ExecStart=%h/scripts/apply_bismuth_mode.sh
+ExecStart=/usr/bin/env apply_bismuth_mode.sh
 
 [Install]
 WantedBy=cyberplasma.target

--- a/cyberplasma/systemd/user/screen-modes.service
+++ b/cyberplasma/systemd/user/screen-modes.service
@@ -6,7 +6,7 @@ Description=Apply saved screen modes
 After=graphical-session.target
 
 [Service]
-ExecStart=%h/scripts/apply_screen_modes.sh
+ExecStart=/usr/bin/env apply_screen_modes.sh
 
 [Install]
 WantedBy=cyberplasma.target

--- a/kde/khotkeysrc
+++ b/kde/khotkeysrc
@@ -16,7 +16,7 @@ ActionsCount=1
 
 [Data_1/Actions/0]
 Type=COMMAND_URL
-CommandURL=~/scripts/toggle_tiling.sh
+CommandURL=toggle_tiling.sh
 
 [Data_1/Triggers]
 TriggersCount=1
@@ -36,7 +36,7 @@ ActionsCount=1
 
 [Data_2/Actions/0]
 Type=COMMAND_URL
-CommandURL=~/scripts/toggle_tiling.sh --grid
+CommandURL=toggle_tiling.sh --grid
 
 [Data_2/Triggers]
 TriggersCount=1
@@ -56,7 +56,7 @@ ActionsCount=1
 
 [Data_3/Actions/0]
 Type=COMMAND_URL
-CommandURL=~/scripts/toggle_tiling.sh --free
+CommandURL=toggle_tiling.sh --free
 
 [Data_3/Triggers]
 TriggersCount=1
@@ -76,7 +76,7 @@ ActionsCount=1
 
 [Data_4/Actions/0]
 Type=COMMAND_URL
-CommandURL=~/scripts/cp_layouts.py cycle next
+CommandURL=cp_layouts.py cycle next
 
 [Data_4/Triggers]
 TriggersCount=1
@@ -96,7 +96,7 @@ ActionsCount=1
 
 [Data_5/Actions/0]
 Type=COMMAND_URL
-CommandURL=~/scripts/cp_layouts.py cycle prev
+CommandURL=cp_layouts.py cycle prev
 
 [Data_5/Triggers]
 TriggersCount=1
@@ -116,7 +116,7 @@ ActionsCount=1
 
 [Data_6/Actions/0]
 Type=COMMAND_URL
-CommandURL=~/scripts/cp_layouts.py move up
+CommandURL=cp_layouts.py move up
 
 [Data_6/Triggers]
 TriggersCount=1
@@ -136,7 +136,7 @@ ActionsCount=1
 
 [Data_7/Actions/0]
 Type=COMMAND_URL
-CommandURL=~/scripts/cp_layouts.py move down
+CommandURL=cp_layouts.py move down
 
 [Data_7/Triggers]
 TriggersCount=1
@@ -156,7 +156,7 @@ ActionsCount=1
 
 [Data_8/Actions/0]
 Type=COMMAND_URL
-CommandURL=~/scripts/cp_layouts.py move left
+CommandURL=cp_layouts.py move left
 
 [Data_8/Triggers]
 TriggersCount=1
@@ -176,7 +176,7 @@ ActionsCount=1
 
 [Data_9/Actions/0]
 Type=COMMAND_URL
-CommandURL=~/scripts/cp_layouts.py move right
+CommandURL=cp_layouts.py move right
 
 [Data_9/Triggers]
 TriggersCount=1

--- a/scripts/apply_bismuth_mode.sh
+++ b/scripts/apply_bismuth_mode.sh
@@ -8,5 +8,13 @@ STATE_FILE="$STATE_DIR/bismuth_mode"
 
 if [[ -f "$STATE_FILE" ]]; then
     mode=$(<"$STATE_FILE")
-    "$HOME"/scripts/toggle_tiling.sh --"$mode"
+    SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+    if [[ -x "$SCRIPT_DIR/toggle_tiling.sh" ]]; then
+        "$SCRIPT_DIR/toggle_tiling.sh" --"$mode"
+    elif command -v toggle_tiling.sh >/dev/null 2>&1; then
+        toggle_tiling.sh --"$mode"
+    else
+        echo "Error: toggle_tiling.sh not found" >&2
+        exit 1
+    fi
 fi

--- a/scripts/apply_screen_modes.sh
+++ b/scripts/apply_screen_modes.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
 # Apply previously saved screen modes on login.
 set -euo pipefail
-"$HOME"/scripts/mode_engine.sh
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+if [[ -x "$SCRIPT_DIR/mode_engine.sh" ]]; then
+    "$SCRIPT_DIR/mode_engine.sh"
+elif command -v mode_engine.sh >/dev/null 2>&1; then
+    mode_engine.sh
+else
+    echo "Error: mode_engine.sh not found" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- allow scripts to locate helper tools via `$BASH_SOURCE` or `$PATH`
- update systemd units, hotkey configs, and docs for new script lookup

## Testing
- `pytest`
- `bats tests/shell` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is no longer signed)*
- `pip install bats-core` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a574fb09248325b304a6f5ace7404f