### PR TITLE
Add Makefile target for shell tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: test-shell
+
+test-shell:
+	@if command -v bats >/dev/null 2>&1; then \
+		bats tests/shell; \
+	else \
+		echo "bats not found. To run shell tests, execute:"; \
+		echo "  docker run --rm -v $$PWD:/repo -w /repo bats/bats:1.11.0 bats tests/shell"; \
+	fi


### PR DESCRIPTION
## Summary
- add root Makefile with `test-shell` target
- run shell tests with local Bats or print Docker command when absent

## Testing
- `make test-shell`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a67742fd04832589d4a1231fd5c445