### PR TITLE
Use CYBERPLASMA_ROOT for EWW widget assets

### DIFF
--- a/cyberplasma/eww/widgets/control_strip.yuck
+++ b/cyberplasma/eww/widgets/control_strip.yuck
@@ -18,22 +18,24 @@
 (defpoll mpris :interval "2s" :command "../scripts/mpris.sh" :json true)
 
 (defwidget control_strip []
-  (svg :path "../../../chrome/control_strip_skinned.svg"
+  (svg :path (format "%s/chrome/control_strip_skinned.svg" (getenv "CYBERPLASMA_ROOT"))
        (slot slot-pins (box :class "slot-pins"))
        (slot slot-net (box :class "slot-net" :halign "start" :valign "center" :spacing 4
                                   (label :class "iface" :text "${net.interface}")
                                   (label :class "local-ip" :text "${local_ip[net.interface]}")
                                   (label :class "public-ip" :text "${public_ip.ip}")
                                   (image :class "vpn-icon" :width 16 :height 16
-                                         :path (if vpn.vpn "../../../icons/icon_vpn_on.svg" "../../../icons/icon_vpn_off.svg"))))
+                                         :path (if vpn.vpn
+                                                    (format "%s/icons/icon_vpn_on.svg" (getenv "CYBERPLASMA_ROOT"))
+                                                    (format "%s/icons/icon_vpn_off.svg" (getenv "CYBERPLASMA_ROOT"))))))
        (slot slot-viz (box :class "slot-viz"))
        (slot slot-media (box :class "slot-media" :halign "start" :valign "center" :spacing 4
                                    (mpris_controls :status mpris.status)
                                    (label :class "mpris-text" :text "${mpris.artist} - ${mpris.title}")))
        (slot slot-sysmini (box :class "slot-sysmini" :halign "start" :valign "center" :spacing 8
-                                   (image :path "../../../icons/icon_cpu.svg" :width 16 :height 16)
+                                   (image :path (format "%s/icons/icon_cpu.svg" (getenv "CYBERPLASMA_ROOT")) :width 16 :height 16)
                                    (label :class "cpu" :text "${cpu.usage}%")
-                                   (image :path "../../../icons/icon_temp.svg" :width 16 :height 16)
+                                   (image :path (format "%s/icons/icon_temp.svg" (getenv "CYBERPLASMA_ROOT")) :width 16 :height 16)
                                    (label :class "temp" :text "${temp.temp}°C")
                                    (label :class "ram" :text "${ram.percent}%")))
        (slot slot-time (box :class "slot-time" :halign "center" :valign "center"

--- a/cyberplasma/eww/widgets/left_column.yuck
+++ b/cyberplasma/eww/widgets/left_column.yuck
@@ -37,10 +37,10 @@
   (overlay :class "vitals-panel" :width 420 :height 220
            (image :path (format "%s/chrome/vitals_panel_skinned.svg" (getenv "CYBERPLASMA_ROOT")))
            ;; Icon seats
-           (image :class "cp-chrome" :path "../../../icons/icon_temp.svg" :x "78" :y "36" :width "24" :height "24")
-           (image :class "cp-accent2" :path "../../../icons/icon_command_mode.svg" :x "78" :y "68" :width "24" :height "24")
-           (image :class "cp-chrome" :path "../../../icons/icon_cpu.svg" :x "78" :y "100" :width "24" :height "24")
-           (image :class "cp-chrome" :path "../../../icons/icon_battery.svg" :x "78" :y "132" :width "24" :height "24")
+           (image :class "cp-chrome" :path (format "%s/icons/icon_temp.svg" (getenv "CYBERPLASMA_ROOT")) :x "78" :y "36" :width "24" :height "24")
+           (image :class "cp-accent2" :path (format "%s/icons/icon_command_mode.svg" (getenv "CYBERPLASMA_ROOT")) :x "78" :y "68" :width "24" :height "24")
+           (image :class "cp-chrome" :path (format "%s/icons/icon_cpu.svg" (getenv "CYBERPLASMA_ROOT")) :x "78" :y "100" :width "24" :height "24")
+           (image :class "cp-chrome" :path (format "%s/icons/icon_battery.svg" (getenv "CYBERPLASMA_ROOT")) :x "78" :y "132" :width "24" :height "24")
            ;; Value slots
            (box :x "110" :y "40" :width "290" :height "20" :halign "start" :valign "center"
                 (label :class "temps" :text "CPU ${temp.temp}°C"))


### PR DESCRIPTION
## Summary
- reference CYBERPLASMA_ROOT for control_strip assets
- reference CYBERPLASMA_ROOT for left_column icons

## Testing
- `pre-commit run --files cyberplasma/eww/widgets/control_strip.yuck cyberplasma/eww/widgets/left_column.yuck` *(fails: command not found)*
- `CYBERPLASMA_ROOT=/workspace/Project-CyberPlasma eww --config ~/.config/eww open control_strip` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a68d7774108325ba4c5ece76c3541a