### PR TITLE
Refine temperature polling and RAM usage visualization

### DIFF
--- a/cyberplasma/eww/widgets/left_column.yuck
+++ b/cyberplasma/eww/widgets/left_column.yuck
@@ -7,8 +7,8 @@
 ;; Network activity
 (defpoll net :interval "2s" :command "../scripts/net.sh $(../scripts/default_iface.sh)" :json true)
 
-;; Temperature (first available sensor)
-(defpoll temp :interval "5s" :command "../scripts/temp.sh | jq '{temp: (.[keys[0]])}'" :json true)
+;; Temperature (explicit CPU thermal zone)
+(defpoll temp :interval "5s" :command "../scripts/temp.sh cpu_thermal_zone" :json true)
 ;; Uptime
 (defpoll uptime :interval "60s" :command "sh -c 'uptime -p | sed \"s/^up //\"'")
 ;; Load averages

--- a/cyberplasma/scripts/ram.sh
+++ b/cyberplasma/scripts/ram.sh
@@ -9,5 +9,6 @@ available=$(awk '/^MemAvailable:/ {print $2}' "$meminfo")
 used=$((total - available))
 
 percent=$(awk -v u="$used" -v t="$total" 'BEGIN { if (t > 0) printf "%.2f", (u / t) * 100; else print "0.00" }')
+used_dots=$(awk -v u="$used" -v t="$total" 'BEGIN { if (t > 0) { v=int((u / t) * 240); if (v > 240) v=240; print v } else print 0 }')
 
-printf '{"total_kb":%s,"used_kb":%s,"percent":%s}\n' "$total" "$used" "$percent"
+printf '{"total_kb":%s,"used_kb":%s,"percent":%s,"used_dots":%s}\n' "$total" "$used" "$percent" "$used_dots"


### PR DESCRIPTION
## Summary
- Poll CPU temperature from a specific `cpu_thermal_zone`
- Report RAM usage as a 0–240 `used_dots` value for the dot matrix display
- Leverage existing dot matrix thresholds to flag high RAM usage

## Testing
- `make test`
- `pre-commit run --files cyberplasma/eww/widgets/left_column.yuck cyberplasma/scripts/ram.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a68d7854908325a4e735aa9129420c