### PR TITLE
Make top_bar width configurable

### DIFF
--- a/cyberplasma/eww/widgets/top_bar.yuck
+++ b/cyberplasma/eww/widgets/top_bar.yuck
@@ -17,8 +17,8 @@
 (defpoll mpris :interval "2s" :command "../scripts/mpris.sh" :json true)
 
 ;; Top bar widget
-(defwidget top_bar []
-  (overlay :class "top-bar" :width 1920 :height 56
+(defwidget top_bar [width]
+  (overlay :class "top-bar" :width width :height 56
            (image :path (format "%s/chrome/control_strip_skinned.svg" (getenv "CYBERPLASMA_ROOT")))
            ;; Network slot
            (box :class "slot-net" :x "250" :y "12" :width "150" :height "32" :halign "start" :valign "center" :spacing 4


### PR DESCRIPTION
## Summary
- Allow top_bar widget to accept width parameter and use it for overlay width

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a68d78de648325a2437d65848f70f8