### PR TITLE
Add control strip pins, viz toggle, and mode badge

### DIFF
--- a/cyberplasma/eww/widgets/control_strip.yuck
+++ b/cyberplasma/eww/widgets/control_strip.yuck
@@ -17,16 +17,24 @@
 ;; Media info
 (defpoll mpris :interval "2s" :command "../scripts/mpris.sh" :json true)
 
+;; Current tiling mode (command/control)
+(defpoll mode :interval "2s" :command "../scripts/current_mode.sh")
+
 (defwidget control_strip []
   (svg :path "../../../chrome/control_strip_skinned.svg"
-       (slot slot-pins (box :class "slot-pins"))
+       (slot slot-pins (box :class "slot-pins" :spacing 4
+                                (button :class "pin" :onclick "konsole" (image :path "../../../icons/icon_app_terminal.svg" :width 24 :height 24))
+                                (button :class "pin" :onclick "firefox" (image :path "../../../icons/icon_app_browser.svg" :width 24 :height 24))
+                                (button :class "pin" :onclick "dolphin" (image :path "../../../icons/icon_app_files.svg" :width 24 :height 24))))
        (slot slot-net (box :class "slot-net" :halign "start" :valign "center" :spacing 4
                                   (label :class "iface" :text "${net.interface}")
                                   (label :class "local-ip" :text "${local_ip[net.interface]}")
                                   (label :class "public-ip" :text "${public_ip.ip}")
                                   (image :class "vpn-icon" :width 16 :height 16
                                          :path (if vpn.vpn "../../../icons/icon_vpn_on.svg" "../../../icons/icon_vpn_off.svg"))))
-       (slot slot-viz (box :class "slot-viz"))
+       (slot slot-viz (box :class "slot-viz"
+                             (button :class "viz-toggle" :onclick "../scripts/toggle_viz.sh"
+                                     (image :path "../../../icons/icon_music.svg" :width 24 :height 24))))
        (slot slot-media (box :class "slot-media" :halign "start" :valign "center" :spacing 4
                                    (mpris_controls :status mpris.status)
                                    (label :class "mpris-text" :text "${mpris.artist} - ${mpris.title}")))
@@ -38,4 +46,8 @@
                                    (label :class "ram" :text "${ram.percent}%")))
        (slot slot-time (box :class "slot-time" :halign "center" :valign "center"
                             (label :class "datetime" :text "${datetime}")))
-       (slot slot-modebadge (box :class "slot-modebadge"))))
+       (slot slot-modebadge (box :class "slot-modebadge"
+                                  (image :width 24 :height 24
+                                         :path (if (= mode "grid")
+                                                   "../../../icons/icon_command_mode.svg"
+                                                   "../../../icons/icon_control_mode.svg"))))))

--- a/icons/icon_app_browser.svg
+++ b/icons/icon_app_browser.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="4" ry="4" fill="#4c566a"/>
+  <text x="16" y="22" font-size="18" text-anchor="middle" fill="#eceff4" font-family="sans-serif">B</text>
+</svg>

--- a/icons/icon_app_files.svg
+++ b/icons/icon_app_files.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="4" ry="4" fill="#4c566a"/>
+  <text x="16" y="22" font-size="18" text-anchor="middle" fill="#eceff4" font-family="sans-serif">F</text>
+</svg>

--- a/icons/icon_app_terminal.svg
+++ b/icons/icon_app_terminal.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="4" ry="4" fill="#4c566a"/>
+  <text x="16" y="22" font-size="18" text-anchor="middle" fill="#eceff4" font-family="sans-serif">T</text>
+</svg>

--- a/scripts/current_mode.sh
+++ b/scripts/current_mode.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Output current Bismuth mode, defaults to 'free' if state file missing.
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}"
+STATE_FILE="$STATE_DIR/bismuth_mode"
+if [[ -f "$STATE_FILE" ]]; then
+  cat "$STATE_FILE"
+else
+  echo free
+fi

--- a/scripts/toggle_viz.sh
+++ b/scripts/toggle_viz.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Toggle GLava and CAVA visualizers.
+# Starts glava if neither is running, otherwise switches between them.
+set -euo pipefail
+if pgrep -x glava >/dev/null 2>&1; then
+  pkill glava
+  if command -v cava >/dev/null 2>&1; then
+    cava &
+  fi
+elif pgrep -x cava >/dev/null 2>&1; then
+  pkill cava
+  if command -v glava >/dev/null 2>&1; then
+    glava &
+  fi
+else
+  if command -v glava >/dev/null 2>&1; then
+    glava &
+  elif command -v cava >/dev/null 2>&1; then
+    cava &
+  fi
+fi


### PR DESCRIPTION
## Summary
- show pinned terminal, browser, and file manager buttons on the control strip
- add a GLava/CAVA toggle button
- display command or control mode badge based on current Bismuth state

## Testing
- `python -m pip install -r requirements.txt`
- `pytest`
- `bats tests/shell`


------
https://chatgpt.com/codex/tasks/task_e_68a68d79b7008325ad18db513b788e22